### PR TITLE
Add Haskell example to comparisons

### DIFF
--- a/theory/comparison/type_clases.hs
+++ b/theory/comparison/type_clases.hs
@@ -1,0 +1,16 @@
+class Stringer t where
+  string :: t -> String
+
+stringify :: Stringer t => [t] -> String
+stringify (only:[]) = string only
+stringify (first:rest) = (string first) ++ (stringify rest)
+
+data MyT = MyT
+
+instance Stringer MyT where
+  string _ = "X"
+
+main :: IO ()
+main = do
+  let v = [MyT, MyT, MyT]
+  putStrLn (stringify v)


### PR DESCRIPTION
Create Haskell equivalent to the example already provided for C++, Rust and Go.