### PR TITLE
Example to focus on PDT limitation

### DIFF
--- a/scenarios/pdt-dilemna/parameterized_modul.F90
+++ b/scenarios/pdt-dilemna/parameterized_modul.F90
@@ -1,0 +1,38 @@
+module foo_mod(k)
+   use, intrinsic :: iso_fortran_env
+   implicit none
+
+   integer :: k
+   
+   type :: foo
+      real(kind=k), allocatable :: data(:)
+   contains
+      procedure :: s
+   end type foo
+
+contains
+
+
+   function s(this)
+      class(foo<k>), intent(in) :: this
+      real(kind=k) :: s
+      s = sum(this%data)
+   end function s
+
+end module foo_mod
+
+program main
+   use foo_mod
+   use, intrinsic :: iso_fortran_env
+   implicit none
+
+   type(foo<real(kind=REAL32)>) :: x32
+   type(foo<real(kind=REAL64>)) :: x64
+
+   x32%data = [1,2,3]
+   x64%data = sqrt(x32%data)
+
+   print*,x32%s()
+   print*,x64%s()
+
+end program main

--- a/scenarios/pdt-dilemna/pdt.F90
+++ b/scenarios/pdt-dilemna/pdt.F90
@@ -1,0 +1,45 @@
+module foo_mod
+   use, intrinsic :: iso_fortran_env
+   implicit none
+   
+   type :: foo(k)
+      integer, kind :: k
+      real(kind=k), allocatable :: data(:)
+   contains
+      procedure :: s32
+      procedure :: s64
+   end type foo
+
+contains
+
+
+   function S32(this)
+      class(foo(k=REAL32)), intent(in) :: this
+      real(kind=this%k) :: s32
+      s32 = sum(this%data)
+   end function S32
+
+   function S64(this)
+      class(foo(k=REAL64)), intent(in) :: this
+      real(kind=this%k) :: s64
+      s64 = sum(this%data)
+   end function S64
+
+end module foo_mod
+
+program main
+   use foo_mod
+   use, intrinsic :: iso_fortran_env
+   implicit none
+
+   type(foo(REAL32)) :: x32
+   type(foo(REAL64)) :: x64
+
+   x32%data = [1,2,3]
+   x64%data = sqrt(x32%data)
+
+   print*,x32%s32()
+   print*,x64%s64()
+
+   print*,x32%s64() ! illegal
+end program main

--- a/scenarios/pdt-dilemna/template.F90
+++ b/scenarios/pdt-dilemna/template.F90
@@ -1,0 +1,39 @@
+module foo_mod
+   use, intrinsic :: iso_fortran_env
+   implicit none
+   
+   type :: foo<k>
+      integer :: k ! not a component!
+      
+      real(kind=k), allocatable :: data(:)
+   contains
+      procedure :: s
+   end type foo
+
+contains
+
+
+   function s<k>(this)
+      integer :: k
+      class(foo<k>), intent(in) :: this
+      real(kind=k) :: s
+      s = sum(this%data)
+   end function s
+
+end module foo_mod
+
+program main
+   use foo_mod
+   use, intrinsic :: iso_fortran_env
+   implicit none
+
+   type(foo<real(kind=REAL32)>) :: x32
+   type(foo<real(kind=REAL64>)) :: x64
+
+   x32%data = [1,2,3]
+   x64%data = sqrt(x32%data)
+
+   print*,x32%s()
+   print*,x64%s()
+
+end program main


### PR DESCRIPTION
- Type bound procedures play poorly with PDT.  An example is
  implemented 3 times: PDT, parameterized modules, and templated
  types. Several issues are worth discussion.