### PR TITLE
An example using new TEMPLATE notation.

### DIFF
--- a/scenarios/axpy_with_arrays/AXPY.F90
+++ b/scenarios/axpy_with_arrays/AXPY.F90
@@ -1,0 +1,54 @@
+module AXPY_m
+
+   public :: axpy_t ! template
+   public :: scalar_op ! restriction
+   public :: assignable ! restriction
+   
+   RESTRICTION elemental_op(T, U, V, F)
+     elemental function F(x,y) result(z)
+       type(T), intent(in) :: x
+       type(U), intent(in) :: y
+       type(V) :: z
+     end function F
+   END RESTRICTION
+
+   RESTRICTION assignable(T, U)
+      elemental assignment(=)(x,y)
+      type(T), intent(out) :: x 
+      type(U), intent(in) :: y
+      end assignment
+   END RESTRICTION
+
+   template axpy_t(T_a, T_x, T_y, T_ax, T_axpy, times, plus)
+
+      type :: T_a
+      end type T_a
+      type :: T_x
+      end type T_x
+      type :: T_y
+      end type T_y
+      type :: T_ax
+      end type T_ax
+      type :: T_axpy
+      end type T_axpy
+
+      procedure :: times
+      procedure :: plus
+      
+      REQUIRES elemental_op(T_a, T_x, T_ax, times)
+      REQUIRES elemental_op(T_ax, T_y, T_axpy, plus)
+      REQUIRES assignable(T_y, T_axpy)
+
+   contains
+
+      subroutine AXPY(a, x, y)
+         type(T), intent(in) :: a
+         type(U), intent(in) :: x
+         type(V), intent(inout) :: y
+
+         y = plus(times(a,x), y)
+      end subroutine AXPY
+
+   END TEMPLATE
+
+end module AXPY_m

--- a/scenarios/axpy_with_arrays/Array.F90
+++ b/scenarios/axpy_with_arrays/Array.F90
@@ -13,7 +13,7 @@ module Array_m
       
       interface assignment(=)
          module procedure assign_from_raw
-         module_procedure assign_to_raw
+         module procedure assign_to_raw
       end interface assignment(=)
 
    contains

--- a/scenarios/axpy_with_arrays/Array.F90
+++ b/scenarios/axpy_with_arrays/Array.F90
@@ -1,0 +1,70 @@
+module Array_m
+
+   public :: Array_t ! template
+
+   TEMPLATE Array_t(T, rank)
+      type :: t
+      end type t
+      integer :: rank
+
+      type :: Array
+         type(T), rank(rank), allocatable :: elements
+      end type Array
+      
+      interface assignment(=)
+         module procedure assign_from_raw
+         module_procedure assign_to_raw
+      end interface assignment(=)
+
+   contains
+
+      subroutine assign_from_raw(x,y)
+         type(Array), intent(out) :: x
+         type(T), rank(rank), intent(in) :: y
+         x%elements = y
+      end subroutine assign_from_raw
+
+      subroutine assign_to_raw(x,y)
+         type(T), rank(rank), allocatable, intent(out) :: x
+         type(Array), intent(in) :: x
+         x = y%elements
+      end subroutine assign_to_raw
+
+   END TEMPLATE
+
+   ! Q: How do we specify that an proc must be elemental?
+   template map_t(T, rank_T, U, rank_U, V, rank_V, W, F)
+      type :: T
+      end type T
+      type :: U
+      end type U
+      type :: V
+      end type V
+      type :: W
+      end type W
+      integer :: rank_T, rank_U, rank_V
+      procedure :: F
+ 
+      REQUIRES :: scalar_op(T, U, V, F)
+      REQUIRES :: assignable(V, W)
+
+   contains
+
+      elemental subroutine map(a, b) result(c)
+         INSTANTIATE Array_t(T, rank_T), only: Array_of_T
+         INSTANTIATE Array_t(U, rank_U), only: Array_of_U
+         INSTANTIATE Array_t(W, rank_V), only: Array_of_W
+         
+         type(Array_of_T), intent(in) :: a
+         type(Array_of_U), intent(in) :: b
+         type(Array_of_W) :: c
+
+         ! exploit that F must be elemental
+         c%elements = F(a%elements, b%elements)
+      end subroutine map
+
+   END TEMPLATE
+
+end module Array_m
+
+

--- a/scenarios/axpy_with_arrays/README.md
+++ b/scenarios/axpy_with_arrays/README.md
@@ -1,0 +1,59 @@
+The files in this directory are an attempt to demonstrate several
+ideas that were bantered about at the last subgroup telecon:
+
+  1. Introduce a new TEMPLATE construct - sort of like an inner
+     parameterized module.
+  2. How can a map procedure be combined with a rank-agnostic Array
+     wrapper template, to provide operations on the wrapped elements?
+  3. Use procedures instead of operators as template arguments.  (More
+     general, and sidesteps some anoying notation issues to a degree.)
+	 
+	 
+	 
+I chose to try to implement an AXPY template that implements `a*x +
+y`.  Conventionally, this is for the case where `a` is a scalar and
+`x` and `y` are 1D arrays, but here we want something that will work
+with any types and ranks that are conformable, but wrapped as Array
+types.
+
+Files:
+
+ - AXPY.F90 - AXPY template and some useful RESTRICTIONS
+ - Array.F90 - Array template, with copy constructors, and element map
+   function
+ - driver.F90 - sews it together with
+   - `a` being a real scalar (wrapped),
+   - `x` being a 2D real array (wrapped),
+   - and `y` being a 2D real array.
+   
+   
+Note that I've intentionally made the templates maximally general,
+which in particular means that they take more type parameters for
+intermediate types that might be different.  Note that there is 
+no restriction on the `map_t` template for the arrays to be conformable,
+but I did assume that W = V was conformable.
+
+Some observations:
+
+1. I think the TEMPLATE mechanism is much cleaner than the
+   parameterized module mechanism.  Being able to define a 2nd
+   template in the same scope that uses the first template is a real
+   windfall.
+2. We have no way to specify that arrays are conformable.  There is a
+   runtime aspect of this that is inescapable, as the underlying
+   shapes can be different, but in theory I would like the `map_t`
+   template to require that either all ranks are equal except those
+   that are scalar:
+	 - `(rank_U == rank_T) .or. rank_u*rank_T = 0`
+     - `rank_V == max(rank_T, rank_U)`
+   Do we want to be able to do this?
+3. Procedures might be more general, but this example really does
+   scream for using operators.
+
+4. UGH!!!  This seems much much more complicated for a simple AXPY
+   template than I would have thought.
+   - OTOH, doing a full blown block matrix-matrix multiply this way
+     may not be _that_ much worse.    So maybe just big first step?
+ 
+
+ 

--- a/scenarios/axpy_with_arrays/driver.F90
+++ b/scenarios/axpy_with_arrays/driver.F90
@@ -1,0 +1,27 @@
+program driver
+   use Array_m, only: Array_t
+   use AXPY_m, only: AXPY_t
+
+
+   INSTANTIATE Array_t(real, 0), only: RealScalar => Array   ! scalar
+   INSTANTIATE Array_t(real, 2), only: RealArray_2D => Array ! 2d array
+
+   ! 1. instatiate function for a*x
+   INSTANTIATE map_t(real, 0, real, 2, real, 2, real, operator(*)), only: times => map
+   ! 2. instatiate operator for (ax) + y
+   INSTANTIATE map_t(real, 2, real, 2, real, 2, real, operator(+)), only: plus => map
+   ! 3. instantiate AXPY procedure
+   INSTANTIATE AXPY_T(RealScalar, RealArray_2D, RealArray_2D, RealArray_2D, RealArray_2D, times, plus)
+
+   ! and the rest is easy
+   type(RealScalar) :: a ! coefficient
+   type(RealArray_2d) :: x, y
+
+   a = 2.
+   x = reshape([1,2,3,4,5,6],[2,3]) 
+   
+   ! ta da
+   call AXPY(a, x, y)
+   
+end program driver
+   


### PR DESCRIPTION
The files in this directory are an attempt to demonstrate several
ideas that were bantered about at the last subgroup telecon using
the AXPY algorithm as an example.

  1. Introduce a new TEMPLATE construct - sort of like an inner
     parameterized module.
  2. How can a map procedure be combined with a rank-agnostic Array
     wrapper template, to provide operations on the wrapped elements?
  3. Use procedures instead of operators as template arguments.  (More
     general, and sidesteps some anoying notation issues to a degree.)