### PR TITLE
Issue with 'innermost scoping unit' constraint

### DIFF
--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -21,6 +21,11 @@ been identified so far.
   [named deferred constant]
   named data object with the CONSTANT attribute (????)
 
+* Insert new glossary term
+
+  [deferred argument]
+  named entity that appears in a <deferred-arg-list> (????)
+
 * 7.3.2.1 Type specifier syntax
 
   Extend R702 <type-spec>:

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -183,6 +183,15 @@ Note: Deferred arguments are local identifiers and are not externally
                              <<or>> <deferred-proc-declaration-stmt>
                              <<or>> <deferred-type-declaration-stmt>
 
+Constraint: A <deferred-arg> that appears in a <deferred-arg-decl-stmt>
+            shall be in the <deferred-arg-list> of the innermost
+            TEMPLATE, REQUIREMENT, or simple template procedure in
+            which it appears.
+
+Note: <deferred-arg-list> is part of the TEMPLATE, REQUIREMENT, and
+      STP constructs, and is defined in the 2nd and 3rd generics
+      formal syntax papers.
+
 3.1.1 Syntax for deferred constants
 
 <deferred-const-declaration-stmt> <<is>>
@@ -223,9 +232,6 @@ Constraint: If <explicit-shape-bounds-spec> appears in
 
 <deferred-const> <<is>> <name>
 
-Constraint: Each <deferred-const> shall appear in <deferred-arg-list>
-            of the innermost scoping unit.
-
 A <deferred-const> is a deferred constant.
 
 Some examples of declaring deferred constants are as follows.
@@ -250,10 +256,6 @@ Some examples of declaring deferred constants are as follows.
      PROCEDURE(<interface>) [ :: ] <deferred-proc-list>
 
 <deferred-proc> <<is>> <name>
-
-Constraint: Each <deferred-proc> that appears in a
-            <deferred-proc-declaration-stmt> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
 
 Constraint: Each <deferred-proc> shall appear in a
             <deferred-arg-decl-stmt> or as a <function-name> or
@@ -308,12 +310,6 @@ appears as the <function-name> or <subroutine-name> in an
 
 Constraint: A <deferred-type> or <deferred-class> entity shall not
             appear as <parent-type-name> in an EXTENDS attribute.
-
-Constraint: Each <deferred-type> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
-
-Constraint: Each <deferred-class> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
 
 A <deferred-type> is a deferred type. A <deferred-class> is an
 abstract derived type.

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -187,10 +187,6 @@ Note: Deferred arguments are local identifiers and are not externally
                              <<or>> <deferred-proc-declaration-stmt>
                              <<or>> <deferred-type-declaration-stmt>
 
-Note: <deferred-arg-list> is part of the TEMPLATE, REQUIREMENT, and
-      STP constructs, and is defined in the other generics syntax
-      papers.
-
 3.1.1 Syntax for deferred constants
 
 <deferred-const-declaration-stmt> <<is>>
@@ -230,6 +226,10 @@ Constraint: If <explicit-shape-bounds-spec> appears in
 
 Constraint: Each <deferred-const> shall appear in <deferred-arg-list>
             of the TEMPLATE, REQUIREMENT or STP in which it appears.
+
+Note: <deferred-arg-list> is part of the TEMPLATE, REQUIREMENT, and
+      STP constructs, and is defined in the other generics syntax
+      papers.
 
 <deferred-const> <<is>> <name>
 

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -167,6 +167,10 @@ deferred arguments.
 	       <<or>> <deferred-type>
 	       <<or>> <deferred-class>
 
+Constraint: A <deferred-arg> shall appear in a <deferred-arg-decl-stmt>
+            or as the <function-name> or <subroutine-name> of an
+            <interface-body>.
+
 Constraint: A <deferred-arg> shall have at most one explicit
             specification in a given scoping unit.
 
@@ -183,14 +187,9 @@ Note: Deferred arguments are local identifiers and are not externally
                              <<or>> <deferred-proc-declaration-stmt>
                              <<or>> <deferred-type-declaration-stmt>
 
-Constraint: A <deferred-arg> that appears in a <deferred-arg-decl-stmt>
-            shall be included in the <deferred-arg-list> of the 
-            TEMPLATE, REQUIREMENT, or simple template procedure in
-            which it appears.
-
 Note: <deferred-arg-list> is part of the TEMPLATE, REQUIREMENT, and
-      STP constructs, and is defined in the 2nd and 3rd generics
-      formal syntax papers.
+      STP constructs, and is defined in the other generics syntax
+      papers.
 
 3.1.1 Syntax for deferred constants
 
@@ -229,6 +228,8 @@ Constraint: If <explicit-shape-bounds-spec> appears in
             <deferred-const-declaration-stmt>, then
             <explicit-bounds-expr> shall not appear as a lower bound.
 
+Constraint: Each <deferred-const> shall appear in <deferred-arg-list>
+            of the TEMPLATE, REQUIREMENT or STP in which it appears.
 
 <deferred-const> <<is>> <name>
 
@@ -255,11 +256,10 @@ Some examples of declaring deferred constants are as follows.
 <deferred-proc-declaration-stmt> <<is>>
      PROCEDURE(<interface>) [ :: ] <deferred-proc-list>
 
-<deferred-proc> <<is>> <name>
+Constraint: Each <deferred-proc> shall appear in <deferred-arg-list>
+            of the TEMPLATE, REQUIREMENT or STP in which it appears.
 
-Constraint: Each <deferred-proc> shall appear in a
-            <deferred-arg-decl-stmt> or as a <function-name> or
-            <subroutine-name> within an <interface-body>.
+<deferred-proc> <<is>> <name>
 
 A <deferred-proc> is a deferred procedure.  A <deferred-arg> that
 appears as the <function-name> or <subroutine-name> in an
@@ -303,6 +303,9 @@ appears as the <function-name> or <subroutine-name> in an
 <deferred-type-declaration-stmt>
        <<is>>  TYPE, DEFERRED :: <deferred-type-list>
        <<or>>  CLASS, DEFERRED :: <deferred-class-list>
+
+Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
+            of the TEMPLATE, REQUIREMENT or STP in which it appears.
 
 <deferred-type> <<is>> <name>
 

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -184,7 +184,7 @@ Note: Deferred arguments are local identifiers and are not externally
                              <<or>> <deferred-type-declaration-stmt>
 
 Constraint: A <deferred-arg> that appears in a <deferred-arg-decl-stmt>
-            shall be in the <deferred-arg-list> of the innermost
+            shall be included in the <deferred-arg-list> of the 
             TEMPLATE, REQUIREMENT, or simple template procedure in
             which it appears.
 


### PR DESCRIPTION
There are a few issues with the constraints removed in this edit:

- I think that "innermost scoping unit" here is a bit too vague, especially because...
- This paper does not define \<deferred-arg-list\>, since that comes from papers 2 & 3. There should at least be a note about that.
- I think all of these need to constrain themselves to \<deferred-arg\>s appearing in their declaration statements, like the constraint for deferred procedures. For example, a \<deferred-const\> can appear in an expression context without it appearing in the \<deferred-arg-list\> of the innermost scoping unit, if it's host associated. It's only when the \<deferred-arg\> appears in a declaration context (including a REQUIRES statement) that it must be in the \<deferred-arg-list\>.

Given that, this PR contains my suggested new wording. I think we can combine all of these into a single constraint, plus a note.

The new constraint wording is loosely based on a similar constraint from the F2023 standard:

> C746 A \<type-param-name\> in a \<type-param-def-stmt\> in a \<derived-type-def\> shall be one of the \<type-param-name\>s in the \<derived-type-stmt\> of that \<derived-type-def\>.

But I couldn't find any perfectly analogous existing constraint that I could directly borrow wording from.

If we choose not to combine all 4 of these constraints into 1, we should at least combine the last two, as: "Each \<deferred-type\> or \<deferred-class\> shall appear...", since we do that in the constraint right above those which deals with the EXTENDS attribute.