### PR TITLE
Use ABSTRACT keyword to indicate an abstract deferred type, in order to resolve issues with the distinction of deferred-type vs deferred-class

### DIFF
--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,13 +26,6 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
-  Extend C703 from:
-    (R702) The <derived-type-spec> shall not specify an abstract
-    type (7.5.7)
-  To:
-    (R702) The <derived-type-spec> or <deferred-type> shall not specify
-    an abstract type (7.5.7) except when used as an <instantiation-arg>.
-
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,11 +26,18 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
+  Extend C703 from:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7)
+  To:
+    (R702) The <derived-type-spec> or <deferred-type> shall not specify
+    an abstract type (7.5.7) except when used as an <instantiation-arg> (????)
+
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 
   Extend R703 <declaration-type-spec>:
-  "CLASS(<deferred-class>)"
+  "CLASS(<deferred-type>)"
 
 * 7.5.2.1 Syntax of a derived-type definition
 
@@ -104,7 +111,7 @@ would make constraint for deferred constants clearer.
   R1156 <type-guard-stmt>
       <<is>> TYPE IS ( <type-spec> ) [ <select-construct-name> ]
       <<or>> CLASS IS ( <derived-type-spec> ) [ <select-construct-name> ]
-      <<or>> CLASS IS ( <deferred-class> ) [ <select-construct-name> ]
+      <<or>> CLASS IS ( <deferred-type> ) [ <select-construct-name> ]
       <<or>> CLASS DEFAULT [ <select-construct-name> ]
 
 * 15.5.1 Syntax of a procedure reference

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -31,7 +31,7 @@ been identified so far.
     type (7.5.7)
   To:
     (R702) The <derived-type-spec> or <deferred-type> shall not specify
-    an abstract type (7.5.7) except when used as an <instantiation-arg> (????)
+    an abstract type (7.5.7) except when used as an <instantiation-arg>.
 
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,6 +26,13 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
+  Extend C703 from:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7)
+  To:
+    (R702) The <derived-type-spec> or <deferred-type> shall not specify
+    an abstract type (7.5.7) except when used as an <instantiation-arg>.
+
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -36,8 +36,24 @@ been identified so far.
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 
+  Change C706 from:
+    (R703) TYPE(<derived-type-spec>) shall not specify an abstract
+    type (7.5.7).
+  To:
+    (R703) In a <declaration-type-spec> that uses the TYPE keyword,
+    <derived-type-spec> or <deferred-type> shall not specify an
+    abstract type (7.5.7).
+
   Extend R703 <declaration-type-spec>:
   "CLASS(<deferred-type>)"
+
+  Extend C705 from:
+    (R703) In a <declaration-type-spec> that uses the CLASS keyword,
+    <derived-type-spec> shall specify an extensible type (7.5.7).
+  To:
+    (R703) In a <declaration-type-spec> that uses the CLASS keyword,
+    <derived-type-spec> or <deferred-type> shall specify an extensible
+    type (7.5.7).
 
 * 7.5.2.1 Syntax of a derived-type definition
 
@@ -113,6 +129,9 @@ would make constraint for deferred constants clearer.
       <<or>> CLASS IS ( <derived-type-spec> ) [ <select-construct-name> ]
       <<or>> CLASS IS ( <deferred-type> ) [ <select-construct-name> ]
       <<or>> CLASS DEFAULT [ <select-construct-name> ]
+
+  Add constraint, or amend C1166 to include:
+    (R1156) <deferred-type> shall specify an extensible type.
 
 * 15.5.1 Syntax of a procedure reference
 

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -314,7 +314,7 @@ Constraint: A <deferred-type> entity shall not appear as
 Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
             of the innermost scoping unit.
 
-A <deferred-type> is a type that is a deferred argument.
+A <deferred-type> is a deferred type.
 
 If ABSTRACT appears in <deferred-type-declaration-stmt>, the declared
 deferred types act as if they were abstract extensible derived types.

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -109,15 +109,19 @@ REQUIRES and INSTANTIATE statements.
 A deferred constant is a deferred argument that can appear in constant
 expressions within a REQUIREMENT construct, TEMPLATE construct, or STP.
 
-A deferred type is a deferred argument that can appear as a
-<type-spec> within a REQUIREMENT construct, TEMPLATE construct, or
-STP.
-
 A deferred procedure is a deferred argument that can appear in
 procedure references within a REQUIREMENT construct, TEMPLATE
 construct, or STP.  A deferred procedure's interface shall be
 established in that construct, possibly in terms of other deferred
 arguments.
+
+A deferred type is a deferred argument that can appear as a
+<type-spec>, or in a <declaration-type-spec> or <type-guard-stmt>,
+within a REQUIREMENT construct, TEMPLATE construct, or STP.
+
+Note: A deferred type is not a <type-name> and cannot not appear
+      in a <derived-type-spec>. Consequently a deferred type may
+      not be used in a <structure-constructor>.
 
 Within a construct with a <deferred-arg>, an explicit specification of
 that <deferred-arg> is either <deferred-arg-explicit-stmt> or
@@ -299,40 +303,52 @@ appears as the <function-name> or <subroutine-name> in an
 
 
 <deferred-type-declaration-stmt>
-       <<is>>  TYPE, DEFERRED :: <deferred-type-list>
-       <<or>>  CLASS, DEFERRED :: <deferred-class-list>
+       <<is>>  TYPE, DEFERRED [, ABSTRACT] :: <deferred-type-list>
+       <<or>>  TYPE, ABSTRACT, DEFERRED :: <deferred-type-list>
 
 <deferred-type> <<is>> <name>
 
-<deferred-class> <<is>> <name>
+Constraint: A <deferred-type> entity shall not appear as
+            <parent-type-name> in an EXTENDS attribute.
 
-Constraint: A <deferred-type> or <deferred-class> entity shall not
-            appear as <parent-type-name> in an EXTENDS attribute.
+Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
+            of the innermost scoping unit.
 
-Constraint: Each <deferred-type> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
+A <deferred-type> is a type that is a deferred argument.
 
-Constraint: Each <deferred-class> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
+If ABSTRACT appears in <deferred-type-declaration-stmt>, the
+declaration specifies the ABSTRACT attribute for the deferred types.
 
-A <deferred-type> is a deferred type. A <deferred-class> is an
-abstract derived type.
+Note: If a deferred type has the ABSTRACT attribute, its corresponding
+      instantiation argument must be an extensible derived type. 
+      This note is formally specified by a constraint in the 2nd paper.
 
-Note: <deferred-type> will not be allowed in a CLASS declaration, and
-      a <deferred-class> will not be allowed in a TYPE declaration.
-      These are implied by extensions planned for section 7.3.2.1 Type
-      specifier syntax.
+If a deferred type does not have the ABSTRACT attribute, it acts as
+if its instantiation argument were non-extensible.
 
-      Simple example illustrating the above.
+Note: The distinction between abstract and non-abstract deferred types
+      is to ensure a processor can verify the usages of deferred types
+      within a template or requirement are compatible with any
+      instantiation arguments they may have.
+
+      The instantiation argument for an abstract deferred type does
+      not need to itself be abstract, but usage of that deferred type
+      within the template or requirement will act as if the
+      instantiation type were abstract.
+
+      The result is that an abstract deferred type may appear in a
+      CLASS declaration but not a TYPE declaration, and a non-abstract
+      deferred type may appear in a TYPE declaration but not a CLASS
+      declaration. An example:
 
       TEMPLATE TMPL(T, U)
          TYPE, DEFERRED :: T
-         CLASS, DEFERRED :: U
+         TYPE, ABSTRACT, DEFERRED :: U
       CONTAINS
          SUBROUTINE S(X, Y, Z, W)
-            TYPE(T) :: X ! ok
+            TYPE(T) :: X  ! ok
             CLASS(T) :: Y ! invalid
-            TYPE(U) :: Z ! invalid
+            TYPE(U) :: Z  ! invalid
             CLASS(U) :: W ! ok
          END SUBROUTINE S
       END TEMPLATE TMPL
@@ -438,15 +454,14 @@ Constraint: If any ultimate specification of a deferred argument is a
             deferred type, then all ultimate specifications of that
             deferred argument shall be deferred type.
 
-Constraint: If any ultimate specification of a deferred argument is a
-            deferred class, then all ultimate specifications of that
-            deferred argument shall be deferred class.
+Constraint: If any ultimate specification of a deferred type is
+            abstract, then all ultimate specifications of that
+            deferred type shall be abstract.
 
-If any ultimate specification is deferred type, then that argument is
-deferred type.
-
-If any ultimate specification is deferred class, then that argument is
-deferred class.
+If any ultimate specification of a deferred argument is deferred type,
+then that argument is deferred type. If any ultimate specification of
+a deferred type has the ABSTRACT attribute, then that argument has the
+ABSTRACT attribute.
 
 3.3 Deferred argument association
 ---------------------------------

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -316,30 +316,15 @@ Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
 
 A <deferred-type> is a type that is a deferred argument.
 
-If ABSTRACT appears in <deferred-type-declaration-stmt>, the
-declaration specifies the ABSTRACT attribute for the deferred types.
-
-Note: If a deferred type has the ABSTRACT attribute, its corresponding
-      instantiation argument must be an extensible derived type. 
-      This note is formally specified by a constraint in the 2nd paper.
-
-If a deferred type does not have the ABSTRACT attribute, it acts as
-if its instantiation argument were non-extensible.
+If ABSTRACT appears in <deferred-type-declaration-stmt>, the declared
+deferred types act as if they were abstract extensible derived types.
+Otherwise, they act as if they were non-extensible types.
 
 Note: The distinction between abstract and non-abstract deferred types
-      is to ensure a processor can verify the usages of deferred types
-      within a template or requirement are compatible with any
-      instantiation arguments they may have.
-
-      The instantiation argument for an abstract deferred type does
-      not need to itself be abstract, but usage of that deferred type
-      within the template or requirement will act as if the
-      instantiation type were abstract.
-
-      The result is that an abstract deferred type may appear in a
-      CLASS declaration but not a TYPE declaration, and a non-abstract
-      deferred type may appear in a TYPE declaration but not a CLASS
-      declaration. An example:
+      helps to ensure a processor can verify a template is internally
+      consistent.  For example, a deferred type must not be permitted
+      in a CLASS declaration if it might be instantiated as INTEGER.
+      The following is a simple usage example:
 
       TEMPLATE TMPL(T, U)
          TYPE, DEFERRED :: T
@@ -352,6 +337,9 @@ Note: The distinction between abstract and non-abstract deferred types
             CLASS(U) :: W ! ok
          END SUBROUTINE S
       END TEMPLATE TMPL
+
+      INSTANTIATE TMPL{INTEGER, MYTYPE} ! both args ok
+      INSTANTIATE TMPL{MYTYPE, INTEGER} ! both args invalid
 
 
 3.2 Specification of deferred arguments

--- a/J3-Papers/syntax-template-and-instantiate.txt
+++ b/J3-Papers/syntax-template-and-instantiate.txt
@@ -389,25 +389,23 @@ Note: The previous two constraints constitute what is referred to as
 
 Constraint: An <instantiation-arg> that is a <type-spec> shall
             correspond to a <deferred-arg> that is a <deferred-type>
-            or <deferred-class> in the referenced template or
-            requirement.
+            in the referenced template or requirement.
 
-Constraint: An <instantiation-arg> that corresponds to a
-            <deferred-type> shall not be abstract.
+Constraint: An <instantiation-arg> that corresponds to a non-abstract
+            deferred type shall not be abstract.
 
-Constraint: If an <instantiation-arg> is associated with a
-            <deferred-type>, a variable of that type shall be
-            permitted in a variable definition context.
+Constraint: An <instantiation-arg> that corresponds to an abstract
+            deferred type shall be an extensible derived type.
 
-Constraint: If an <instantiation-arg> is a <type-spec>, it shall not
-            specify a type that has a coarray potential subobject
+Constraint: An <instantiation-arg> that corresponds to a deferred
+            type shall be permitted in a variable definition context.
+
+Constraint: An <instantiation-arg> that corresponds to a deferred
+            type shall not have a coarray potential subobject
             component.
 
-Constraint: If an <instantiation-arg> corresponds to <deferred-class>,
-            it shall be extensible.
-
 Note: Non-abstract, extensible derived types can be associated with
-      both <deferred-class> and <deferred-type>.
+      both abstract and non-abstract deferred type arguments.
 
       Simple example illustrating the above.
 
@@ -421,7 +419,7 @@ Note: Non-abstract, extensible derived types can be associated with
       END TEMPLATE TMPL
 
       TEMPLATE TMPL2(U)
-         CLASS, DEFERRED :: U
+         TYPE, ABSTRACT, DEFERRED :: U
       END TEMPLATE TMPL
 
       INSTANTIATE TMPL1(INTEGER) ! ok

--- a/J3-Papers/syntax-template-and-instantiate.txt
+++ b/J3-Papers/syntax-template-and-instantiate.txt
@@ -394,11 +394,12 @@ Constraint: An <instantiation-arg> that is a <type-spec> shall
 Constraint: An <instantiation-arg> that corresponds to a non-abstract
             deferred type shall not be abstract.
 
+Constraint: An <instantiation-arg> that corresponds to a non-abstract
+            deferred type shall be permitted in a variable definition
+            context.
+
 Constraint: An <instantiation-arg> that corresponds to an abstract
             deferred type shall be an extensible derived type.
-
-Constraint: An <instantiation-arg> that corresponds to a deferred
-            type shall be permitted in a variable definition context.
 
 Constraint: An <instantiation-arg> that corresponds to a deferred
             type shall not have a coarray potential subobject


### PR DESCRIPTION
There are inconsistencies with the usage of "deferred type"/\<deferred-type\> and "deferred class"/\<deferred-class\>

* https://github.com/j3-fortran/generics/blob/cc42f87f976b4a151111c349498e826ff5b8aa18/J3-Papers/syntax-intro-and-deferred-args.txt#L112-L114
* https://github.com/j3-fortran/generics/blob/cc42f87f976b4a151111c349498e826ff5b8aa18/J3-Papers/syntax-intro-and-deferred-args.txt#L318-L319
* https://github.com/j3-fortran/generics/blob/cc42f87f976b4a151111c349498e826ff5b8aa18/J3-Papers/syntax-intro-and-deferred-args.txt#L437-L449

In the third of those 3 snippets, we assume that "deferred type" and "deferred class" are mutually exclusive categories. However, in the first snippet, as well as the section headers in the document, we refer to both things together as "deferred type". We also say "can appear in a \<type-spec\>" in the first snippet, which is not true of deferred class. We also group them in the BNF, such as "\<deferred-type-declaration-stmt\>" which is either TYPE, DEFERRED or CLASS, DEFERRED. We need to be more precise with the terms here.

In the existing standard, "class" is not a term used to describe a type, and it's not really even a word used to describe a data object. I think the closest it gets to that is the "CLASS IS" syntax in a \<type-guard-stmt\>. CLASS is only a type specifier which declares polymorphic data objects. I think our problem might be the use of the word "class" at all to describe the concept we want; when I see CLASS in Fortran, I think "declaration of an object", not "definition of a type".

The `TYPE, DEFERRED :: type-name` declaration is supposed to be analogous to the `TYPE :: type-name` construct, right? So I think it would be more clear to use `TYPE, ABSTRACT, DEFERRED :: type-name` as the declaration, analogous to `TYPE, ABSTRACT :: type-name`.

With that notion, this PR is my proposal to address the inconsistencies between \<deferred-type\> and \<deferred-class\>.

If the `TYPE, ABSTRACT, DEFERRED :: type-name` syntax is not preferred, we could still revert back to the `CLASS, DEFERRED :: type-name` syntax and keep everything else in this edit the same, except the normative text would change to:

> If **[[ABSTRACT appears -> CLASS is used]]** in \<deferred-type-declaration-stmt\>, the declared
deferred types act as if they were abstract extensible derived types.
Otherwise, they act as if they were non-extensible types.
