### PR TITLE
Indicate that template argument association is permitted in a REQUIREMENT construct

### DIFF
--- a/J3-Papers/syntax-requirement-and-requires.txt
+++ b/J3-Papers/syntax-requirement-and-requires.txt
@@ -75,7 +75,7 @@ Constraint: If a <requirement-name> appears in the <end-requirement-stmt>,
             specified in the <requirement-stmt>.
 
 Note: A <requirement> is a scoping unit that allows use, host, and
-      template argument association.
+      instantiation argument association.
 
 Note: Each <deferred-arg> is local to the REQUIREMENT construct.
 

--- a/J3-Papers/syntax-requirement-and-requires.txt
+++ b/J3-Papers/syntax-requirement-and-requires.txt
@@ -74,8 +74,8 @@ Constraint: If a <requirement-name> appears in the <end-requirement-stmt>,
             it shall be identical to the <requirement-name>
             specified in the <requirement-stmt>.
 
-Note: A <requirement> is a scoping unit that allows use and host
-      association.
+Note: A <requirement> is a scoping unit that allows use, host, and
+      template argument association.
 
 Note: Each <deferred-arg> is local to the REQUIREMENT construct.
 


### PR DESCRIPTION
It should have template argument association, correct?

Also, I'm not sure if this should be a note or normative text. In the syntax-template-and-instantiate.txt paper, the analogous information is in normative text.