### PR TITLE
Combine similar rank & shape constraints for clarity, fix issue with deferred rank deferred constants

### DIFF
--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -353,28 +353,22 @@ Constraint: If any ultimate specification of a deferred argument is a
 Constraint: All specifications of a deferred constant shall specify
             the same type and kind-type parameters.
 
+Constraint: If any ultimate specification of a deferred constant is of
+            a non-deferred rank R, then an explicit specification of
+            that deferred constant shall have rank R, and all other
+            ultimate specifications of that deferred constant shall
+            either have deferred rank or have rank R.
+
 Constraint: If any ultimate specification of a deferred constant has
             explicit shape S, then an explicit specification of that
-            deferred constant shall have explicit shape S, and all other
+            deferred constant shall have shape S, and all other
             ultimate specifications of that deferred constant shall
-            have deferred rank, implied shape with the same rank as
-            S, or explicit shape S.
-
-Constraint: If any ultimate specification of a deferred constant has
-            implied shape with rank R, then an explicit specification
-            of that deferred constant shall have explicit or implied
-            shape of rank R, and all other ultimate specifications
-            of that deferred constant shall have deferred rank or
-            implied shape of rank R.
-
-If any ultimate specification of a deferred constant has a
-non-deferred rank, R, then that deferred constant has rank
-R.  Otherwise it has deferred rank.
+            have deferred rank, implied shape, or shape S.
 
 If any ultimate specification of a deferred constant has an explicit
 shape S, then that deferred constant has shape S.  Otherwise, if any
-ultimate specification of a deferred constant has implied shape, then
-that deferred constant has the same implied shape. Otherwise it has
+ultimate specification of that deferred constant has implied shape,
+then it has implied shape with the same rank.  Otherwise it has
 deferred rank.
 
 3.2.2 Specification of deferred procedures

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -353,32 +353,29 @@ Constraint: If any ultimate specification of a deferred argument is a
 Constraint: All specifications of a deferred constant shall specify
             the same type and kind-type parameters.
 
-Constraint: If any ultimate specification of a deferred constant is of
-            a non-deferred rank, R, then an explicit specification of
-            that deferred constant shall have rank R.
-
-Constraint: If any ultimate specification of a deferred constant is of
-            a non-deferred rank, R, then all other specifications of
-            that deferred constant shall either have deferred rank or
-            have rank R.
-
 Constraint: If any ultimate specification of a deferred constant has
             explicit shape S, then an explicit specification of that
-            deferred constant shall have shape S.
+            deferred constant shall have explicit shape S, and all other
+            ultimate specifications of that deferred constant shall
+            have deferred rank, implied shape with the same rank as
+            S, or explicit shape S.
 
 Constraint: If any ultimate specification of a deferred constant has
-	    explicit shape S, then all other specifications of that
-	    deferred constant shall either have deferred rank or
-	    implied shape, or the same shape S.
-
+            implied shape with rank R, then an explicit specification
+            of that deferred constant shall have explicit or implied
+            shape of rank R, and all other ultimate specifications
+            of that deferred constant shall have deferred rank or
+            implied shape of rank R.
 
 If any ultimate specification of a deferred constant has a
 non-deferred rank, R, then that deferred constant has rank
 R.  Otherwise it has deferred rank.
 
 If any ultimate specification of a deferred constant has an explicit
-shape S, then that deferred constant has shape S.  Otherwise the it
-has implied shape.
+shape S, then that deferred constant has shape S.  Otherwise, if any
+ultimate specification of a deferred constant has implied shape, then
+that deferred constant has the same implied shape. Otherwise it has
+deferred rank.
 
 3.2.2 Specification of deferred procedures
 


### PR DESCRIPTION
This PR changes the 4 constraints on rank and shape for deferred constants to merge the two rank constraints into one, and merge the two shape constraints into one. I did that because when I first read the 4 constraints, I was very confused how they were different, because I was still a bit confused about explicit and ultimate specifications. I initially thought the pairs of constraints were duplicates and one of each could be removed. I think by combining them, it becomes more clear that there is no duplicate parts. It's also less text!

(Also, I made this other variation of the constraints which I think is effectively the same but structured differently. Just another option to consider if you don't like what's in the main PR edit.
```
Constraint: If any ultimate specification of a deferred constant has
            explicit shape S, then an explicit specification of that
            deferred constant shall have explicit shape S, and all other
            ultimate specifications of that deferred constant shall
            have deferred rank, implied shape with the same rank as
            S, or explicit shape S.

Constraint: If any ultimate specification of a deferred constant has
            implied shape with rank R, then an explicit specification
            of that deferred constant shall have explicit or implied
            shape of rank R, and all other ultimate specifications
            of that deferred constant shall have deferred rank or
            implied shape of rank R.
```
)


However, while I made that change, I realized the normative text was insufficient to handle the case where all ultimate specifications are deferred rank. For reference, here was the previous normative text:

> If any ultimate specification of a deferred constant has a non-deferred rank, R, then that deferred constant has rank R.  Otherwise it has deferred rank.
> 
> If any ultimate specification of a deferred constant has an explicit shape S, then that deferred constant has shape S.  Otherwise the it has implied shape.

If all ultimate specifications are deferred rank, the 1st paragraph says the deferred constant is deferred rank, but the 2nd paragraph says it has implied shape. Both of those cannot be true at once. To fix that, I combined all three cases (explicit shape, implied shape, deferred rank) into one paragraph and sorted them by precedence:

> If any ultimate specification of a deferred constant has an explicit shape S, then that deferred constant has shape S.  Otherwise, if any ultimate specification of that deferred constant has implied shape, then it has implied shape with the same rank.  Otherwise it has deferred rank.

It's a similar structure to the variations of the constraints I wrote above in the PR description, which is why I thought they might be nice, to match the structure of this new normative text.