### PR TITLE
Add missing 'ultimate' before 'specifications'

### DIFF
--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -347,11 +347,11 @@ the outermost scope in which it is a deferred argument.
 3.2.1 Specification of deferred constants
 
 Constraint: If any ultimate specification of a deferred argument is a
-            deferred constant, then all specifications of that deferred
-            argument shall be deferred constant.
+            deferred constant, then all ultimate specifications of
+            that deferred argument shall be deferred constant.
 
-Constraint: All specifications of a deferred constant shall specify
-            the same type and kind-type parameters.
+Constraint: All ultimate specifications of a deferred constant shall
+            specify the same type and kind-type parameters.
 
 Constraint: If any ultimate specification of a deferred constant is of
             a non-deferred rank, R, then an explicit specification of
@@ -383,22 +383,22 @@ has implied shape.
 3.2.2 Specification of deferred procedures
 
 Constraint: If any ultimate specification of a deferred argument is a
-            deferred procedure, then all specifications of that
-            deferred argument shall be deferred procedure.
+            deferred procedure, then all ultimate specifications of
+            that deferred argument shall be deferred procedure.
 
 Constraint: If any ultimate specification of a deferred argument is a
-            subroutine, then all specifications of that deferred
-            argument shall be a subroutine.
+            subroutine, then all ultimate specifications of that
+            deferred argument shall be a subroutine.
 
 Constraint: If any ultimate specification of a deferred argument is a
-            function, then all specifications of that deferred
+            function, then all ultimate specifications of that deferred
             argument shall be a function.
 
 Constraint: A deferred procedure shall only be referenced with keyword
             arguments if it has an explicit specification.
 
-Constraint: Except for PURE, SIMPLE, and ELEMENTAL
-            attributes, the characteristics of all specifications of a
+Constraint: Except for PURE, SIMPLE, and ELEMENTAL attributes, the
+            characteristics of all ultimate specifications of a
             deferred procedure shall be consistent.
 
 Constraint: If any ultimate specification of a deferred procedure is
@@ -413,15 +413,15 @@ Constraint: If any ultimate specification of a deferred procedure is
             ELEMENTAL, then an explicit specification of that deferred
             procedure shall be ELEMENTAL.
 
-If any specification of a deferred procedure is SIMPLE then that
-deferred procedure is SIMPLE.
+If any ultimate specification of a deferred procedure is SIMPLE then
+that deferred procedure is SIMPLE.
 
-If any specification of a deferred procedure is PURE and none of the
-specifications of that deferred procedure are SIMPLE, then that deferred
-procedure is PURE.
+If any ultimate specification of a deferred procedure is PURE and none
+of the ultimate specifications of that deferred procedure are SIMPLE,
+then that deferred procedure is PURE.
 
-If any specification of a deferred procedure is ELEMENTAL then that
-deferred procedure is ELEMENTAL.
+If any ultimate specification of a deferred procedure is ELEMENTAL then
+that deferred procedure is ELEMENTAL.
 
 Only an explicit specification of a <deferred-proc> defines the names
 of its dummy arguments.


### PR DESCRIPTION
Most places that say "specifications" specifically say "ultimate specifications", but there were some that didn't. I added "ultimate" to them for clarity.