### PR TITLE
Remove redundant procedure constraints and combine some procedure normative text

### DIFF
--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -386,14 +386,6 @@ Constraint: If any ultimate specification of a deferred argument is a
             deferred procedure, then all specifications of that
             deferred argument shall be deferred procedure.
 
-Constraint: If any ultimate specification of a deferred argument is a
-            subroutine, then all specifications of that deferred
-            argument shall be a subroutine.
-
-Constraint: If any ultimate specification of a deferred argument is a
-            function, then all specifications of that deferred
-            argument shall be a function.
-
 Constraint: A deferred procedure shall only be referenced with keyword
             arguments if it has an explicit specification.
 
@@ -413,12 +405,9 @@ Constraint: If any ultimate specification of a deferred procedure is
             ELEMENTAL, then an explicit specification of that deferred
             procedure shall be ELEMENTAL.
 
-If any specification of a deferred procedure is SIMPLE then that
-deferred procedure is SIMPLE.
-
-If any specification of a deferred procedure is PURE and none of the
-specifications of that deferred procedure are SIMPLE, then that deferred
-procedure is PURE.
+If any ultimate specification of a deferred procedure is SIMPLE then
+that deferred procedure is SIMPLE. Otherwise, if any ultimate
+specification of that deferred procedure is PURE, then it is PURE.
 
 If any specification of a deferred procedure is ELEMENTAL then that
 deferred procedure is ELEMENTAL.


### PR DESCRIPTION
For the normative text part, I thought it was just more concise to combine those two paragraphs.

For the constraint part, the constraints about functions and subroutines are redundant because of this constraint:

```
Constraint: Except for PURE, SIMPLE, and ELEMENTAL
            attributes, the characteristics of all specifications of a
            deferred procedure shall be consistent.
```

From F2023:
> The characteristics of a procedure are the classification of the procedure as a function or subroutine, ...

Since the function or subroutine-ness are characteristics, the constraint written above covers both of the removed constraints in this edit.