### PR TITLE
Reword ambiguous constraint on keyword arguments, and remove outdated note on keyword arguments

### DIFF
--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -394,8 +394,8 @@ Constraint: If any ultimate specification of a deferred argument is a
             function, then all specifications of that deferred
             argument shall be a function.
 
-Constraint: A deferred procedure shall only be referenced with keyword
-            arguments if it has an explicit specification.
+Constraint: A deferred procedure shall not be referenced with keyword
+            arguments unless it has an explicit specification.
 
 Constraint: Except for PURE, SIMPLE, and ELEMENTAL
             attributes, the characteristics of all specifications of a
@@ -425,11 +425,6 @@ deferred procedure is ELEMENTAL.
 
 Only an explicit specification of a <deferred-proc> defines the names
 of its dummy arguments.
-
-Note: Unless a <deferred-proc> has an explicit specification, the
-      names of its dummy arguments are processor-dependent.  The
-      intent is that users be unable to access the arguments via
-      keywords.
 
 
 3.2.3 Specification of deferred types


### PR DESCRIPTION
The existing wording of the constraint
> A deferred procedure shall only be referenced with keyword arguments if it has an explicit specification.

Can be interpreted two ways:
1. (The intended interpretation) A deferred procedure *may only* (shall only) be referenced with keyword arguments if it has an explicit specification.
2. (Other interpretation) A deferred procedure *must* (shall only) be referenced with keyword arguments if it has an explicit specification.

I continue to naturally interpret the sentence in the 2nd way, and it took re-reading a few times it a day later to realize what the constraint is trying to say. If you're not seeing it, consider the sentence without the "if" clause at the end:

> A deferred procedure shall only be referenced with keyword arguments.

In this shortened version, it's clear that "shall only" is interchangeable with "must". If you take that whole shortened sentence as the subject of the "if", then you get the 2nd interpretation. But if you replace "shall only" with "may only" in the shortened sentence, then it's clear that a conditional is needed. May only... when? That gets you the 1st interpretation.

Anyway, I replaced it with an unambiguous version.

<hr>

As for the note, I assume it was added before this constraint existed? With the constraint, the note no longer makes sense, because "The intent is that users be unable to access the arguments via keywords." is clearly expressed by the constraint. And "the names of its dummy arguments are processor-dependent." is, well, not wrong I guess, but irrelevant.

