### PR TITLE
Add 'except when used as an <instantiation-arg>'

### DIFF
--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,6 +26,13 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
+  Extend C703 from:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7)
+  To:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7) except when used as an <instantiation-arg>.
+
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 


### PR DESCRIPTION
Currently this is our syntax for instantiation-arg:
```
<instantiation-arg> <<is>> <constant-expr>
                    <<or>> <type-spec>
                    <<or>> <generic-spec>
                    <<or>> <procedure-name>
```
This PR considers the case where \<type-spec\> is used. Here is the definition of \<type-spec\>, plus its constraint:
```
R702 <type-spec> <<is>> <intrinsic-type-spec>
                 <<or>> <derived-type-spec>
                 <<or>> <enum-type-spec>
                 <<or>> <enumeration-type-spec>

C703 (R702) The <derived-type-spec> shall not specify an abstract type (7.5.7).
```

We want to allow an \<instantiation-arg\> to be an abstract derived type. For example:
```
type, abstract :: my_t
    ...
end type
instantiate tmpl{my_t}
```
In this example, \<instantiation-arg\> is a \<type-spec\> which is a \<derived-type-spec\>. And so the constraint applies, which is not what we want.

We could fix this by using something else than \<type-spec\>, but the simplest solution that I see is to add an exception to the constraint.