### PR TITLE
Use attributes for deferred type

### DIFF
--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -33,8 +33,9 @@ been identified so far.
     (R702) The <derived-type-spec> or <deferred-type> shall not specify
     an abstract type (7.5.7) except when used as an <instantiation-arg>.
 
-  Extend R703 <declaration-type-spec>:
-  "TYPE(<deferred-type>)"
+  Extend R703 <declaration-type-spec> to include:
+      <<or>> TYPE(<deferred-type>)
+      <<or>> CLASS(<deferred-type>)
 
   Change C706 from:
     (R703) TYPE(<derived-type-spec>) shall not specify an abstract
@@ -43,9 +44,6 @@ been identified so far.
     (R703) In a <declaration-type-spec> that uses the TYPE keyword,
     <derived-type-spec> or <deferred-type> shall not specify an
     abstract type (7.5.7).
-
-  Extend R703 <declaration-type-spec>:
-  "CLASS(<deferred-type>)"
 
   Extend C705 from:
     (R703) In a <declaration-type-spec> that uses the CLASS keyword,
@@ -130,7 +128,7 @@ would make constraint for deferred constants clearer.
       <<or>> CLASS IS ( <deferred-type> ) [ <select-construct-name> ]
       <<or>> CLASS DEFAULT [ <select-construct-name> ]
 
-  Add constraint, or amend C1166 to include:
+  Add constraint:
     (R1156) <deferred-type> shall specify an extensible type.
 
 * 15.5.1 Syntax of a procedure reference

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,13 +26,6 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
-  Extend C703 from:
-    (R702) The <derived-type-spec> shall not specify an abstract
-    type (7.5.7)
-  To:
-    (R702) The <derived-type-spec> or <deferred-type> shall not specify
-    an abstract type (7.5.7) except when used as an <instantiation-arg>.
-
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,11 +26,18 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
+  Extend C703 from:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7)
+  To:
+    (R702) The <derived-type-spec> or <deferred-type> shall not specify
+    an abstract type (7.5.7) except when used as an <instantiation-arg> (????)
+
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 
   Extend R703 <declaration-type-spec>:
-  "CLASS(<deferred-class>)"
+  "CLASS(<deferred-type>)"
 
 * 7.5.2.1 Syntax of a derived-type definition
 
@@ -104,7 +111,7 @@ would make constraint for deferred constants clearer.
   R1156 <type-guard-stmt>
       <<is>> TYPE IS ( <type-spec> ) [ <select-construct-name> ]
       <<or>> CLASS IS ( <derived-type-spec> ) [ <select-construct-name> ]
-      <<or>> CLASS IS ( <deferred-class> ) [ <select-construct-name> ]
+      <<or>> CLASS IS ( <deferred-type> ) [ <select-construct-name> ]
       <<or>> CLASS DEFAULT [ <select-construct-name> ]
 
 * 15.5.1 Syntax of a procedure reference

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -31,7 +31,7 @@ been identified so far.
     type (7.5.7)
   To:
     (R702) The <derived-type-spec> or <deferred-type> shall not specify
-    an abstract type (7.5.7) except when used as an <instantiation-arg> (????)
+    an abstract type (7.5.7) except when used as an <instantiation-arg>.
 
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -26,6 +26,13 @@ been identified so far.
   Extend R702 <type-spec>:
   " <<or>> <deferred-type>"
 
+  Extend C703 from:
+    (R702) The <derived-type-spec> shall not specify an abstract
+    type (7.5.7)
+  To:
+    (R702) The <derived-type-spec> or <deferred-type> shall not specify
+    an abstract type (7.5.7) except when used as an <instantiation-arg>.
+
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 

--- a/J3-Papers/misc-template-edits.txt
+++ b/J3-Papers/misc-template-edits.txt
@@ -36,8 +36,24 @@ been identified so far.
   Extend R703 <declaration-type-spec>:
   "TYPE(<deferred-type>)"
 
+  Change C706 from:
+    (R703) TYPE(<derived-type-spec>) shall not specify an abstract
+    type (7.5.7).
+  To:
+    (R703) In a <declaration-type-spec> that uses the TYPE keyword,
+    <derived-type-spec> or <deferred-type> shall not specify an
+    abstract type (7.5.7).
+
   Extend R703 <declaration-type-spec>:
   "CLASS(<deferred-type>)"
+
+  Extend C705 from:
+    (R703) In a <declaration-type-spec> that uses the CLASS keyword,
+    <derived-type-spec> shall specify an extensible type (7.5.7).
+  To:
+    (R703) In a <declaration-type-spec> that uses the CLASS keyword,
+    <derived-type-spec> or <deferred-type> shall specify an extensible
+    type (7.5.7).
 
 * 7.5.2.1 Syntax of a derived-type definition
 
@@ -113,6 +129,9 @@ would make constraint for deferred constants clearer.
       <<or>> CLASS IS ( <derived-type-spec> ) [ <select-construct-name> ]
       <<or>> CLASS IS ( <deferred-type> ) [ <select-construct-name> ]
       <<or>> CLASS DEFAULT [ <select-construct-name> ]
+
+  Add constraint, or amend C1166 to include:
+    (R1156) <deferred-type> shall specify an extensible type.
 
 * 15.5.1 Syntax of a procedure reference
 

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -314,7 +314,7 @@ Constraint: A <deferred-type> entity shall not appear as
 Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
             of the innermost scoping unit.
 
-A <deferred-type> is a type that is a deferred argument.
+A <deferred-type> is a deferred type.
 
 If ABSTRACT appears in <deferred-type-declaration-stmt>, the declared
 deferred types act as if they were abstract extensible derived types.

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -109,15 +109,19 @@ REQUIRES and INSTANTIATE statements.
 A deferred constant is a deferred argument that can appear in constant
 expressions within a REQUIREMENT construct, TEMPLATE construct, or STP.
 
-A deferred type is a deferred argument that can appear as a
-<type-spec> within a REQUIREMENT construct, TEMPLATE construct, or
-STP.
-
 A deferred procedure is a deferred argument that can appear in
 procedure references within a REQUIREMENT construct, TEMPLATE
 construct, or STP.  A deferred procedure's interface shall be
 established in that construct, possibly in terms of other deferred
 arguments.
+
+A deferred type is a deferred argument that can appear as a
+<type-spec>, or in a <declaration-type-spec> or <type-guard-stmt>,
+within a REQUIREMENT construct, TEMPLATE construct, or STP.
+
+Note: A deferred type is not a <type-name> and cannot not appear
+      in a <derived-type-spec>. Consequently a deferred type may
+      not be used in a <structure-constructor>.
 
 Within a construct with a <deferred-arg>, an explicit specification of
 that <deferred-arg> is either <deferred-arg-explicit-stmt> or
@@ -299,40 +303,52 @@ appears as the <function-name> or <subroutine-name> in an
 
 
 <deferred-type-declaration-stmt>
-       <<is>>  TYPE, DEFERRED :: <deferred-type-list>
-       <<or>>  CLASS, DEFERRED :: <deferred-class-list>
+       <<is>>  TYPE, DEFERRED [, ABSTRACT] :: <deferred-type-list>
+       <<or>>  TYPE, ABSTRACT, DEFERRED :: <deferred-type-list>
 
 <deferred-type> <<is>> <name>
 
-<deferred-class> <<is>> <name>
+Constraint: A <deferred-type> entity shall not appear as
+            <parent-type-name> in an EXTENDS attribute.
 
-Constraint: A <deferred-type> or <deferred-class> entity shall not
-            appear as <parent-type-name> in an EXTENDS attribute.
+Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
+            of the innermost scoping unit.
 
-Constraint: Each <deferred-type> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
+A <deferred-type> is a type that is a deferred argument.
 
-Constraint: Each <deferred-class> shall appear in
-            <deferred-arg-list> of the innermost scoping unit.
+If ABSTRACT appears in <deferred-type-declaration-stmt>, the
+declaration specifies the ABSTRACT attribute for the deferred types.
 
-A <deferred-type> is a deferred type. A <deferred-class> is an
-abstract derived type.
+Note: If a deferred type has the ABSTRACT attribute, its corresponding
+      instantiation argument must be an extensible derived type. 
+      This note is formally specified by a constraint in the 2nd paper.
 
-Note: <deferred-type> will not be allowed in a CLASS declaration, and
-      a <deferred-class> will not be allowed in a TYPE declaration.
-      These are implied by extensions planned for section 7.3.2.1 Type
-      specifier syntax.
+If a deferred type does not have the ABSTRACT attribute, it acts as
+if its instantiation argument were non-extensible.
 
-      Simple example illustrating the above.
+Note: The distinction between abstract and non-abstract deferred types
+      is to ensure a processor can verify the usages of deferred types
+      within a template or requirement are compatible with any
+      instantiation arguments they may have.
+
+      The instantiation argument for an abstract deferred type does
+      not need to itself be abstract, but usage of that deferred type
+      within the template or requirement will act as if the
+      instantiation type were abstract.
+
+      The result is that an abstract deferred type may appear in a
+      CLASS declaration but not a TYPE declaration, and a non-abstract
+      deferred type may appear in a TYPE declaration but not a CLASS
+      declaration. An example:
 
       TEMPLATE TMPL(T, U)
          TYPE, DEFERRED :: T
-         CLASS, DEFERRED :: U
+         TYPE, ABSTRACT, DEFERRED :: U
       CONTAINS
          SUBROUTINE S(X, Y, Z, W)
-            TYPE(T) :: X ! ok
+            TYPE(T) :: X  ! ok
             CLASS(T) :: Y ! invalid
-            TYPE(U) :: Z ! invalid
+            TYPE(U) :: Z  ! invalid
             CLASS(U) :: W ! ok
          END SUBROUTINE S
       END TEMPLATE TMPL
@@ -438,15 +454,14 @@ Constraint: If any ultimate specification of a deferred argument is a
             deferred type, then all ultimate specifications of that
             deferred argument shall be deferred type.
 
-Constraint: If any ultimate specification of a deferred argument is a
-            deferred class, then all ultimate specifications of that
-            deferred argument shall be deferred class.
+Constraint: If any ultimate specification of a deferred type is
+            abstract, then all ultimate specifications of that
+            deferred type shall be abstract.
 
-If any ultimate specification is deferred type, then that argument is
-deferred type.
-
-If any ultimate specification is deferred class, then that argument is
-deferred class.
+If any ultimate specification of a deferred argument is deferred type,
+then that argument is deferred type. If any ultimate specification of
+a deferred type has the ABSTRACT attribute, then that argument has the
+ABSTRACT attribute.
 
 3.3 Deferred argument association
 ---------------------------------

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -316,30 +316,15 @@ Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
 
 A <deferred-type> is a type that is a deferred argument.
 
-If ABSTRACT appears in <deferred-type-declaration-stmt>, the
-declaration specifies the ABSTRACT attribute for the deferred types.
-
-Note: If a deferred type has the ABSTRACT attribute, its corresponding
-      instantiation argument must be an extensible derived type. 
-      This note is formally specified by a constraint in the 2nd paper.
-
-If a deferred type does not have the ABSTRACT attribute, it acts as
-if its instantiation argument were non-extensible.
+If ABSTRACT appears in <deferred-type-declaration-stmt>, the declared
+deferred types act as if they were abstract extensible derived types.
+Otherwise, they act as if they were non-extensible types.
 
 Note: The distinction between abstract and non-abstract deferred types
-      is to ensure a processor can verify the usages of deferred types
-      within a template or requirement are compatible with any
-      instantiation arguments they may have.
-
-      The instantiation argument for an abstract deferred type does
-      not need to itself be abstract, but usage of that deferred type
-      within the template or requirement will act as if the
-      instantiation type were abstract.
-
-      The result is that an abstract deferred type may appear in a
-      CLASS declaration but not a TYPE declaration, and a non-abstract
-      deferred type may appear in a TYPE declaration but not a CLASS
-      declaration. An example:
+      helps to ensure a processor can verify a template is internally
+      consistent.  For example, a deferred type must not be permitted
+      in a CLASS declaration if it might be instantiated as INTEGER.
+      The following is a simple usage example:
 
       TEMPLATE TMPL(T, U)
          TYPE, DEFERRED :: T
@@ -352,6 +337,9 @@ Note: The distinction between abstract and non-abstract deferred types
             CLASS(U) :: W ! ok
          END SUBROUTINE S
       END TEMPLATE TMPL
+
+      INSTANTIATE TMPL{INTEGER, MYTYPE} ! both args ok
+      INSTANTIATE TMPL{MYTYPE, INTEGER} ! both args invalid
 
 
 3.2 Specification of deferred arguments

--- a/J3-Papers/syntax-intro-and-deferred-args.txt
+++ b/J3-Papers/syntax-intro-and-deferred-args.txt
@@ -302,9 +302,12 @@ appears as the <function-name> or <subroutine-name> in an
       - class(T) :: local
 
 
-<deferred-type-declaration-stmt>
-       <<is>>  TYPE, DEFERRED [, ABSTRACT] :: <deferred-type-list>
-       <<or>>  TYPE, ABSTRACT, DEFERRED :: <deferred-type-list>
+<deferred-type-declaration-stmt> <<is>> 
+         TYPE, [<deferred-type-attr-list>] DEFERRED 
+         [, <deferred-type-attr-list>] :: <deferred-type-list>
+
+<deferred-type-attr> <<is>> ABSTRACT
+                     <<or>> EXTENSIBLE
 
 <deferred-type> <<is>> <name>
 
@@ -316,30 +319,55 @@ Constraint: Each <deferred-type> shall appear in <deferred-arg-list>
 
 A <deferred-type> is a deferred type.
 
-If ABSTRACT appears in <deferred-type-declaration-stmt>, the declared
-deferred types act as if they were abstract extensible derived types.
-Otherwise, they act as if they were non-extensible types.
+A deferred type with the EXTENSIBLE attribute is an extensible derived
+type.A deferred type with the ABSTRACT is an abstract derived type. A
+deferred type with the ABSTRACT attribute implicitly has the
+EXTENSIBLE attribute.
 
-Note: The distinction between abstract and non-abstract deferred types
-      helps to ensure a processor can verify a template is internally
-      consistent.  For example, a deferred type must not be permitted
-      in a CLASS declaration if it might be instantiated as INTEGER.
-      The following is a simple usage example:
+Note: The distinction between deferred types that are extensible or not,
+      and deferred types which are abstract or not, helps to ensure a
+      processor can verify a template is internally consistent.  For
+      example, a deferred type must not be permitted in a CLASS
+      declaration if it might be instantiated as INTEGER. Additionally,
+      a deferred type must not be permitted in a TYPE declaration if it
+      might be instantiated with an abstract derived type. The following
+      examples illustrate this point:
 
-      TEMPLATE TMPL(T, U)
+      SUBROUTINE S1{T}(X, Y)
          TYPE, DEFERRED :: T
-         TYPE, ABSTRACT, DEFERRED :: U
-      CONTAINS
-         SUBROUTINE S(X, Y, Z, W)
-            TYPE(T) :: X  ! ok
-            CLASS(T) :: Y ! invalid
-            TYPE(U) :: Z  ! invalid
-            CLASS(U) :: W ! ok
-         END SUBROUTINE S
-      END TEMPLATE TMPL
+         TYPE(T)  :: X ! ok
+         CLASS(T) :: Y ! invalid
+      END SUBROUTINE
 
-      INSTANTIATE TMPL{INTEGER, MYTYPE} ! both args ok
-      INSTANTIATE TMPL{MYTYPE, INTEGER} ! both args invalid
+      SUBROUTINE S2{T}(X, Y)
+         TYPE, DEFERRED, EXTENSIBLE :: T
+         TYPE(T)  :: X ! ok
+         CLASS(T) :: Y ! ok
+      END SUBROUTINE
+
+      SUBROUTINE S3{T}(X, Y)
+         TYPE, DEFERRED, ABSTRACT :: T
+         TYPE(T)  :: X ! invalid
+         CLASS(T) :: Y ! ok
+      END SUBROUTINE
+
+      TYPE :: EXT_TYPE
+      END TYPE
+
+      TYPE, ABSTRACT :: ABS_TYPE
+      END ABSTRACT
+
+      INSTANTIATE S1{INTEGER}  ! ok
+      INSTANTIATE S1{EXT_TYPE} ! ok
+      INSTANTIATE S1{ABS_TYPE} ! invalid
+
+      INSTANTIATE S2{INTEGER}  ! invalid
+      INSTANTIATE S2{EXT_TYPE} ! ok
+      INSTANTIATE S2{ABS_TYPE} ! invalid
+
+      INSTANTIATE S3{INTEGER}  ! invalid
+      INSTANTIATE S3{EXT_TYPE} ! ok
+      INSTANTIATE S3{ABS_TYPE} ! ok
 
 
 3.2 Specification of deferred arguments
@@ -422,14 +450,94 @@ Constraint: If any ultimate specification of a deferred argument is a
             deferred type, then all ultimate specifications of that
             deferred argument shall be deferred type.
 
-Constraint: If any ultimate specification of a deferred type is
-            abstract, then all ultimate specifications of that
-            deferred type shall be abstract.
+UTI: Is this how we want this to work?
 
-If any ultimate specification of a deferred argument is deferred type,
-then that argument is deferred type. If any ultimate specification of
-a deferred type has the ABSTRACT attribute, then that argument has the
-ABSTRACT attribute.
+If any ultimate specification of a deferred type has the EXTENSIBLE
+attribute, then the deferred type has the EXTENSIBLE attribute.
+
+   REQUIREMENT R1{U}
+      TYPE, DEFERRED :: U
+   END REQUIREMENT
+
+   REQUIREMENT R2{U}
+      TYPE, DEFERRED, EXTENSIBLE :: U
+   END REQUIREMENT
+
+   REQUIREMENT R3{U}
+      TYPE, DEFERRED, ABSTRACT :: U
+   END REQUIREMENT
+
+   TEMPLATE T1{T}
+      REQUIRES R1{T} ! valid, non-extensible
+   END TEMPLATE
+
+   TEMPLATE T2{T}
+      REQUIRES R2{T} ! valid, extensible
+   END TEMPLATE
+
+   TEMPLATE T3{T}
+      REQUIRES R3{T} ! valid, but T is just extensible
+   END TEMPLATE
+
+   TEMPLATE T4{T}
+      TYPE, DEFERRED :: T
+      REQUIRES R1{T} ! valid, non-extensible
+   END TEMPLATE
+
+   TEMPLATE T5{T}
+      TYPE, DEFERRED :: T
+      REQUIRES R2{T} ! invalid, explicit decl is not extensible
+   END TEMPLATE
+
+   TEMPLATE T6{T}
+      TYPE, DEFERRED :: T
+      REQUIRES R3{T} ! invalid, explicit decl is not extensible
+   END TEMPLATE
+
+   TEMPLATE T7{T}
+      TYPE, DEFERRED, EXTENSIBLE :: T
+      REQUIRES R1{T} ! valid, T is not abstract
+   END TEMPLATE
+
+   TEMPLATE T8{T}
+      TYPE, DEFERRED, EXTENSIBLE :: T
+      REQUIRES R2{T} ! valid, decls match
+   END TEMPLATE
+
+   TEMPLATE T9{T}
+      TYPE, DEFERRED, EXTENSIBLE :: T
+      REQUIRES R3{T} ! valid, T is just extensible
+   END TEMPLATE
+
+   TEMPLATE T10{T}
+      TYPE, DEFERRED, ABSTRACT :: T
+      REQUIRES R1{T} ! invalid, T is abstract
+   END TEMPLATE
+
+   TEMPLATE T11{T}
+      TYPE, DEFERRED, ABSTRACT :: T
+      REQUIRES R2{T} ! invalid, T is abstract
+   END TEMPLATE
+
+   TEMPLATE T12{T}
+      TYPE, DEFERRED, ABSTRACT :: T
+      REQUIRES R3{T} ! valid, decls match
+   END TEMPLATE
+
+   TEMPLATE T13{T}
+      REQUIRES R1{T}
+      REQUIRES R2{T} ! valid, T is extensible
+   END TEMPLATE
+
+   TEMPLATE T14{T}
+      REQUIRES R1{T}
+      REQUIRES R3{T} ! valid, T is just extensible
+   END TEMPLATE
+
+   TEMPLATE T15{T}
+      REQUIRES R2{T}
+      REQUIRES R3{T} ! valid, T is just extensible
+   END TEMPLATE
 
 3.3 Deferred argument association
 ---------------------------------

--- a/J3-Papers/syntax-template-and-instantiate.txt
+++ b/J3-Papers/syntax-template-and-instantiate.txt
@@ -389,25 +389,23 @@ Note: The previous two constraints constitute what is referred to as
 
 Constraint: An <instantiation-arg> that is a <type-spec> shall
             correspond to a <deferred-arg> that is a <deferred-type>
-            or <deferred-class> in the referenced template or
-            requirement.
+            in the referenced template or requirement.
 
-Constraint: An <instantiation-arg> that corresponds to a
-            <deferred-type> shall not be abstract.
+Constraint: An <instantiation-arg> that corresponds to a non-abstract
+            deferred type shall not be abstract.
 
-Constraint: If an <instantiation-arg> is associated with a
-            <deferred-type>, a variable of that type shall be
-            permitted in a variable definition context.
+Constraint: An <instantiation-arg> that corresponds to an abstract
+            deferred type shall be an extensible derived type.
 
-Constraint: If an <instantiation-arg> is a <type-spec>, it shall not
-            specify a type that has a coarray potential subobject
+Constraint: An <instantiation-arg> that corresponds to a deferred
+            type shall be permitted in a variable definition context.
+
+Constraint: An <instantiation-arg> that corresponds to a deferred
+            type shall not have a coarray potential subobject
             component.
 
-Constraint: If an <instantiation-arg> corresponds to <deferred-class>,
-            it shall be extensible.
-
 Note: Non-abstract, extensible derived types can be associated with
-      both <deferred-class> and <deferred-type>.
+      both abstract and non-abstract deferred type arguments.
 
       Simple example illustrating the above.
 
@@ -421,7 +419,7 @@ Note: Non-abstract, extensible derived types can be associated with
       END TEMPLATE TMPL
 
       TEMPLATE TMPL2(U)
-         CLASS, DEFERRED :: U
+         TYPE, ABSTRACT, DEFERRED :: U
       END TEMPLATE TMPL
 
       INSTANTIATE TMPL1(INTEGER) ! ok

--- a/J3-Papers/syntax-template-and-instantiate.txt
+++ b/J3-Papers/syntax-template-and-instantiate.txt
@@ -27,7 +27,7 @@ and inline instantiation of simple template procedures.
 
 An example template is shown below.
 
-   TEMPLATE TMPL(T, F)
+   TEMPLATE TMPL{T, F}
       TYPE, DEFERRED :: T
       INTERFACE
          FUNCTION F(X)
@@ -59,8 +59,8 @@ template is shown below.
 
 Example instantiate statements of TMPL are:
 
-   INSTANTIATE TMPL(integer, operator(-)), only: negate => S
-   INSTANTIATE TMPL(real, sin)
+   INSTANTIATE TMPL{integer, operator(-)}, only: negate => S
+   INSTANTIATE TMPL{real, sin}
 
 An example of an inline instantiation of the simple template
 procedure would be as follows.
@@ -391,27 +391,34 @@ Constraint: An <instantiation-arg> that is a <type-spec> shall
             correspond to a <deferred-arg> that is a <deferred-type>
             in the referenced template or requirement.
 
-Constraint: An <instantiation-arg> that corresponds to a non-abstract
-            deferred type shall not be abstract.
+Constraint: An <instantiation-arg> that corresponds to a deferred type
+            that does not have the ABSTRACT attribute shall not be
+            abstract.
 
-Constraint: An <instantiation-arg> that corresponds to a non-abstract
-            deferred type shall be permitted in a variable definition
-            context.
+Constraint: An <instantiation-arg> that corresponds to a deferred type
+            that does not have the abstract attribute shall be permitted
+            in a variable definition context.
 
-Constraint: An <instantiation-arg> that corresponds to an abstract
-            deferred type shall be an extensible derived type.
+Constraint: An <instantiation-arg> that corresponds to a deferred type 
+            that has the EXTENSIBLE attribute shall be an extensible
+            derived type.
 
 Constraint: An <instantiation-arg> that corresponds to a deferred
             type shall not have a coarray potential subobject
             component.
 
 Note: Non-abstract, extensible derived types can be associated with
-      both abstract and non-abstract deferred type arguments.
+      both abstract and non-extensible deferred type arguments.
+
+Note: Intrinsic types, SEQUENCE types, and types with the BIND attribute
+      cannot be associated with deferred type arguments that have the
+      EXTENSIBLE attribute.
 
       Simple example illustrating the above.
 
       TYPE :: MY_T1
       END TYPE
+
       TYPE, ABSTRACT :: MY_T2
       END TYPE
 

--- a/J3-Papers/syntax-template-and-instantiate.txt
+++ b/J3-Papers/syntax-template-and-instantiate.txt
@@ -394,11 +394,12 @@ Constraint: An <instantiation-arg> that is a <type-spec> shall
 Constraint: An <instantiation-arg> that corresponds to a non-abstract
             deferred type shall not be abstract.
 
+Constraint: An <instantiation-arg> that corresponds to a non-abstract
+            deferred type shall be permitted in a variable definition
+            context.
+
 Constraint: An <instantiation-arg> that corresponds to an abstract
             deferred type shall be an extensible derived type.
-
-Constraint: An <instantiation-arg> that corresponds to a deferred
-            type shall be permitted in a variable definition context.
 
 Constraint: An <instantiation-arg> that corresponds to a deferred
             type shall not have a coarray potential subobject


### PR DESCRIPTION
Uses attributes on `type, deferred ::` to enable use of polymorphism instead of `class, deferred ::`