### PR TITLE
Updating README.md to reflect the fact that Fortran 2023 has been approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This project is to refine concepts for potential features in Fortran 202Y
 that supports generic programming.  (202Y is the internal name for the revision
-_after_ the next revision, and is intentionally vague.)
+after Fortran 2023, and is intentionally vague.)
 
 For now, contributions should largely be in the form of motivating use cases
 and illustrative examples that highlight issues and approaches.


### PR DESCRIPTION
...and that the generics which are slated for 202Y come after Fortran 2023 (and not after the next release).