### PR TITLE
Formatting, mostly indent

### DIFF
--- a/J3-Papers/edits/24-161_concepts.txt
+++ b/J3-Papers/edits/24-161_concepts.txt
@@ -42,15 +42,15 @@ Association with instantiation arguments occurs in the REQUIRE and
 INSTANTIATE statements.
 
 R2001  <deferred-arg> <<is>> <deferred-const-name>
-               <<or>> <deferred-proc>
-               <<or>> <deferred-type>
+                      <<or>> <deferred-proc>
+                      <<or>> <deferred-type>
 
 C2001 (R2001). A <deferred-arg> shall appear in a <deferred-arg-decl-stmt>
-            or as the <function-name> or <subroutine-name> of an
-            <interface-body>.
+               or as the <function-name> or <subroutine-name> of an
+               <interface-body>.
 
 C2002 (R2001). A <deferred-arg> shall have at most one explicit
-            specification in a given scoping unit.
+               specification in a given scoping unit.
 
 Note: Deferred arguments are local identifiers and are not externally
       accessible.
@@ -59,14 +59,15 @@ A deferred argument declaration statement is used to declare
 deferred arguments.
 
 R2002 <deferred-arg-decl-stmt> <<is>> <deferred-arg-explicit-stmt>
-                         <<or>> <require-stmt>
+                               <<or>> <require-stmt>
 
-R2003 <deferred-arg-explicit-stmt> <<is>> <deferred-type-declaration-stmt>
-                             <<or>> <deferred-const-declaration-stmt>
-                             <<or>> <deferred-proc-declaration-stmt>
+R2003 <deferred-arg-explicit-stmt>
+          <<is>> <deferred-type-declaration-stmt>
+          <<or>> <deferred-const-declaration-stmt>
+          <<or>> <deferred-proc-declaration-stmt>
 
 C2003 (R2003). A <deferred-arg-explicit-stmt> shall not have an
-            <access-spec>.
+               <access-spec>.
 
 20.2.1.2 Deferred types
 
@@ -82,16 +83,16 @@ C2004 (R2004). Each <deferred-type-name> shall appear in
                standalone template procedure in which it appears.
 
 R2005 <deferred-type-attr> <<is>> DEFERRED
-                     <<or>> ABSTRACT
-                     <<or>> EXTENSIBLE
+                           <<or>> ABSTRACT
+                           <<or>> EXTENSIBLE
 
 C2005 (R2005). DEFERRED shall appear in each <deferred-type-attr-list>.
 
 C2006 (R2005). The same <deferred-type-attr> shall not appear more than
-            once in a given <deferred-type-attr-list>.
+               once in a given <deferred-type-attr-list>.
 
 C2007 (R2005). A <deferred-type> entity shall not appear as
-            <parent-type-name> in an EXTENDS attribute.
+               <parent-type-name> in an EXTENDS attribute.
 
 Note: A deferred type is not a <type-name>.  Consequently it shall not
       appear as a <derived-type-spec>, and so a deferred type
@@ -159,37 +160,37 @@ R2006 <deferred-const-declaration-stmt> <<is>>
            <deferred-const-entity-decl-list>
 
 R2007 <deferred-const-attr-spec> <<is>> <dimension-spec>
-                           <<or>> DEFERRED
-                           <<or>> PARAMETER
-                           <<or>> <rank-clause>
+                                 <<or>> DEFERRED
+                                 <<or>> PARAMETER
+                                 <<or>> <rank-clause>
 
 R2008 <deferred-const-entity-decl>
-     <<is>> <deferred-const-name> [ ( <array-spec> ) ]
+          <<is>> <deferred-const-name> [ ( <array-spec> ) ]
 
 C2008 (R2007). A <deferred-const-attr-spec-list> shall include both
-            the DEFERRED and PARAMETER keywords.
+               the DEFERRED and PARAMETER keywords.
 
 C2009 (R2007). An entity declared in <deferred-const-declaration-stmt>
-            shall be INTEGER, LOGICAL, or assumed-length CHARACTER.
+               shall be INTEGER, LOGICAL, or assumed-length CHARACTER.
 
 C2010 (R2008). Each <deferred-const-name> shall appear in
-            <deferred-arg-list> of the TEMPLATE, REQUIREMENT or
-            standalone template procedure in which it appears.
+               <deferred-arg-list> of the TEMPLATE, REQUIREMENT or
+               standalone template procedure in which it appears.
 
 C2011 (R2006). If <array-spec> appears in
-            <deferred-const-declaration-stmt>, it shall be
-            <implied-shape-spec>, <assumed-or-implied-rank-spec>,
-            <explicit-shape-spec-list>, or
-            <explicit-shape-bounds-spec>.
+               <deferred-const-declaration-stmt>, it shall be
+               <implied-shape-spec>, <assumed-or-implied-rank-spec>,
+               <explicit-shape-spec-list>, or
+               <explicit-shape-bounds-spec>.
 
 C2012 (R2006). If <implied-shape-spec>, <explicit-shape-spec> or
-            <explicit-shape-bounds-spec> appears in
-            <deferred-const-declaration-stmt>, then <lower-bound>
-            shall not be specified.
+               <explicit-shape-bounds-spec> appears in
+               <deferred-const-declaration-stmt>, then <lower-bound>
+               shall not be specified.
 
 C2013 (R2006). If <explicit-shape-bounds-spec> appears in
-            <deferred-const-declaration-stmt>, then
-            <explicit-bounds-expr> shall not appear as a lower bound.
+               <deferred-const-declaration-stmt>, then
+               <explicit-bounds-expr> shall not appear as a lower bound.
 
 Note: Deferred constants will always have default lower bounds.
 
@@ -224,14 +225,14 @@ R2009 <deferred-proc-declaration-stmt> <<is>>
      PROCEDURE(<interface>), DEFERRED :: <deferred-proc-name-list>
 
 C2014 (R2009). Each <deferred-proc-name> shall appear in the
-            <deferred-arg-list> of the TEMPLATE, REQUIREMENT or
-            standalone template procedure in which it appears.
+               <deferred-arg-list> of the TEMPLATE, REQUIREMENT or
+               standalone template procedure in which it appears.
 
 C2015 (R2009). Each <subroutine-name> or <function-name> of an
-            <interface-body> that appears in a deferred interface
-            block shall appear in the <deferred-arg-list> of the
-            TEMPLATE, REQUIREMENT or standalone template procedure in
-            which it appears.
+               <interface-body> that appears in a deferred interface
+               block shall appear in the <deferred-arg-list> of the
+               TEMPLATE, REQUIREMENT or standalone template procedure in
+               which it appears.
 
 Note: The interface of a deferred procedure may be defined in terms of
       other deferred arguments.

--- a/J3-Papers/edits/24-162_consistency.txt
+++ b/J3-Papers/edits/24-162_consistency.txt
@@ -40,8 +40,8 @@ Note: A deferred argument is always explicitly declared within the
 20.2.2.2 Specification of deferred types
 
 C2016. If any ultimate specification of a deferred argument is a
-            deferred type, then all ultimate specifications of that
-            deferred argument shall be deferred type.
+       deferred type, then all ultimate specifications of that
+       deferred argument shall be deferred type.
 
 If any ultimate specification of a deferred type has the EXTENSIBLE
 attribute, then the deferred type has the EXTENSIBLE attribute.
@@ -149,23 +149,23 @@ NOTE: Examples that illustrate valid and invalid uses of ABSTRACT and
 20.2.2.3 Specification of deferred constants
 
 C2017. If any ultimate specification of a deferred argument is a
-            deferred constant, then all ultimate specifications of
-            that deferred argument shall be deferred constant.
+       deferred constant, then all ultimate specifications of
+       that deferred argument shall be deferred constant.
 
 C2018. All ultimate specifications of a deferred constant shall
-            specify the same type and kind-type parameters.
+       specify the same type and kind-type parameters.
 
 C2019. If any ultimate specification of a deferred constant is of
-            a non-implied rank R, then an explicit specification of
-            that deferred constant shall have rank R, and all other
-            ultimate specifications of that deferred constant shall
-            either have implied rank or have rank R.
+       a non-implied rank R, then an explicit specification of
+       that deferred constant shall have rank R, and all other
+       ultimate specifications of that deferred constant shall
+       either have implied rank or have rank R.
 
 C2020. If any ultimate specification of a deferred constant has
-            explicit shape S, then an explicit specification of that
-            deferred constant shall have shape S, and all other
-            ultimate specifications of that deferred constant shall
-            have implied rank, implied shape, or shape S.
+       explicit shape S, then an explicit specification of that
+       deferred constant shall have shape S, and all other
+       ultimate specifications of that deferred constant shall
+       have implied rank, implied shape, or shape S.
 
 If any ultimate specification of a deferred constant has an explicit
 shape S, then that deferred constant has shape S.  Otherwise, if any
@@ -176,11 +176,11 @@ implied rank.
 20.2.2.4 Specification of deferred procedures
 
 C2021. If any ultimate specification of a deferred argument is a
-            deferred procedure, then all ultimate specifications of
-            that deferred argument shall be deferred procedure.
+       deferred procedure, then all ultimate specifications of
+       that deferred argument shall be deferred procedure.
 
 C2022. A deferred procedure shall not be referenced with keyword
-            arguments unless it has an explicit specification.
+       arguments unless it has an explicit specification.
 
 Note: Although dummy arguments always have names, they are processor-
       dependent for deferred procedures without an explicit
@@ -188,23 +188,23 @@ Note: Although dummy arguments always have names, they are processor-
       be used.
 
 C2023. Except for PURE, SIMPLE, and ELEMENTAL attributes, the
-            characteristics of all ultimate specifications of a
-            deferred procedure shall be consistent.
+       characteristics of all ultimate specifications of a
+       deferred procedure shall be consistent.
 
 Note: The characteristics of a procedure do not include the names
       of the dummy arguments, so they need not be the same.
 
 C2024. If any ultimate specification of a deferred procedure is
-            SIMPLE, then an explicit specification of that deferred
-            procedure shall be SIMPLE.
+       SIMPLE, then an explicit specification of that deferred
+       procedure shall be SIMPLE.
 
 C2025. If any ultimate specification of a deferred procedure is
-            PURE, then an explicit specification of that deferred
-            procedure shall be PURE or SIMPLE.
+       PURE, then an explicit specification of that deferred
+       procedure shall be PURE or SIMPLE.
 
 C2026. If any ultimate specification of a deferred procedure is
-            ELEMENTAL, then an explicit specification of that deferred
-            procedure shall be ELEMENTAL.
+       ELEMENTAL, then an explicit specification of that deferred
+       procedure shall be ELEMENTAL.
 
 If any ultimate specification of a deferred procedure is SIMPLE then
 that deferred procedure is SIMPLE. Otherwise, if any ultimate

--- a/J3-Papers/edits/24-163_templates.txt
+++ b/J3-Papers/edits/24-163_templates.txt
@@ -22,9 +22,9 @@ A TEMPLATE construct defines a template that may define multiple
 entities which may be accessed through instantiation.
 
 R2010 <template> <<is>> <template-stmt>
-                      [ <template-specification-part> ]
-                      [ <template-subprogram-part> ]
-                      <end-template-stmt>
+                        [ <template-specification-part> ]
+                        [ <template-subprogram-part> ]
+                        <end-template-stmt>
 
 R2011 <template-stmt> <<is>>
           TEMPLATE <template-name> ([<deferred-arg-list>])
@@ -32,38 +32,38 @@ R2011 <template-stmt> <<is>>
 R2012 <end-template-stmt> <<is>>  END [TEMPLATE [<template-name>]]
 
 C2027 (R2012). If a <template-name> appears in the <end-template-stmt>,
-            it shall be identical to the <template-name>
-            specified in the <template-stmt>.
+               it shall be identical to the <template-name>
+               specified in the <template-stmt>.
 
 20.3.2 Template specification part
 
 R2013 <template-specification-part> <<is>>
-            [ <use-stmt> ] ...
-	    [ <import-stmt> ] ...
-            [ <template-declaration-construct> ] ...
+          [ <use-stmt> ] ...
+          [ <import-stmt> ] ...
+          [ <template-declaration-construct> ] ...
 
 The implicit mapping within <template> is as if
        IMPLICIT NONE(TYPE,EXTERNAL)
 is specified.
 
 R2014 <template-declaration-construct>
-         <<is>> <template-specification-construct>
-         <<or>> <deferred-arg-decl-stmt>
-         <<or>> <requirement>
-         <<or>> <template>
+          <<is>> <template-specification-construct>
+          <<or>> <deferred-arg-decl-stmt>
+          <<or>> <requirement>
+          <<or>> <template>
 
 R2015 <template-specification-construct>
-                      <<is>> <access-stmt>
-                      <<or>> <derived-type-def>
-                      <<or>> <dimension-stmt>
-                      <<or>> <enum-def>
-                      <<or>> <enumeration-type-def>
-                      <<or>> <generic-stmt>
-                      <<or>> <instantiate-stmt>
-		      <<or>> <interface-block>
-                      <<or>> <intrinsic-stmt>
-                      <<or>> <parameter-stmt>
-                      <<or>> <type-declaration-stmt>
+          <<is>> <access-stmt>
+          <<or>> <derived-type-def>
+          <<or>> <dimension-stmt>
+          <<or>> <enum-def>
+          <<or>> <enumeration-type-def>
+          <<or>> <generic-stmt>
+          <<or>> <instantiate-stmt>
+          <<or>> <interface-block>
+          <<or>> <intrinsic-stmt>
+          <<or>> <parameter-stmt>
+          <<or>> <type-declaration-stmt>
 
 Note: An ALLOCATABLE, ASYNCHRONOUS, BIND, CODIMENSION, COMMON,
       CONTIGUOUS, DATA, ENTRY, EQUIVALENCE, EXTERNAL, FORMAT, INTENT,
@@ -72,7 +72,7 @@ Note: An ALLOCATABLE, ASYNCHRONOUS, BIND, CODIMENSION, COMMON,
       template specification section.
 
 C2028 (R2015). An entity declared by <type-declaration-stmt> shall have
-            the PARAMETER attribute.
+               the PARAMETER attribute.
 
 Note: This is to say, the template specification section cannot
       declare variables.
@@ -81,12 +81,13 @@ Note: This is to say, the template specification section cannot
 20.3.3 Template subprogram part
 
 R2016 <template-subprogram-part> <<is>> <contains-stmt>
-                                     [ <template-subprogram> ] ...
+                                        [ <template-subprogram> ] ...
 
-R2017 <template-subprogram> <<is>> <function-subprogram>
-                      <<or>> <subroutine-subprogram>
-		      <<or>> <standalone-template-function-subprogram>
-		      <<or>> <standalone-template-subroutine-subprogram>
+R2017 <template-subprogram>
+          <<is>> <function-subprogram>
+          <<or>> <subroutine-subprogram>
+          <<or>> <standalone-template-function-subprogram>
+          <<or>> <standalone-template-subroutine-subprogram>
 
 20.4 Standalone template procedures
 
@@ -95,63 +96,63 @@ procedure which is accessible via instantiation.
 
 
 R2018 <standalone-template-function-subprogram> <<is>>
-       <standalone-template-function-stmt>
-         <standalone-template-subprogram-specification-part>
-         [<execution-part>]
-         [<internal-subprogram-part>]
-         <end-function-stmt>
+          <standalone-template-function-stmt>
+          <standalone-template-subprogram-specification-part>
+          [<execution-part>]
+          [<internal-subprogram-part>]
+          <end-function-stmt>
 
 C2029 (R2018). If a <function-name> appears in the <end-function-stmt>,
-            it shall be identical to the <template-name>
-            specified in the <standalone-template-function-stmt>.
+               it shall be identical to the <template-name>
+               specified in the <standalone-template-function-stmt>.
 
 C2030 (R2018). An internal <standalone-template-function-subprogram>
-            shall not contain an <internal-subprogram-part>.
+               shall not contain an <internal-subprogram-part>.
 
 R2019 <standalone-template-subroutine-subprogram> <<is>>
-       <standalone-template-subroutine-stmt>
-         <standalone-template-subprogram-specification-part>
-         [<execution-part>]
-         [<internal-subprogram-part>]
-         <end-subroutine-stmt>
+          <standalone-template-subroutine-stmt>
+          <standalone-template-subprogram-specification-part>
+          [<execution-part>]
+          [<internal-subprogram-part>]
+          <end-subroutine-stmt>
 
 C2031 (R2019). If a <subroutine-name> appears in the <end-subroutine-stmt>,
-            it shall be identical to the <template-name>
-            specified in the <standalone-template-subroutine-stmt>.
+               it shall be identical to the <template-name>
+               specified in the <standalone-template-subroutine-stmt>.
 
 C2032 (R2019). An internal <standalone-template-subroutine-subprogram>
-            shall not contain an <internal-subprogram-part>.
+               shall not contain an <internal-subprogram-part>.
 
 R2020 <standalone-template-subprogram-specification-part> <<is>>
-     [ <use-stmt> ] ...
-     [ <import-stmt> ] ...
-     [ <standalone-template-subprogram-declaration-construct> ] ...
+          [ <use-stmt> ] ...
+          [ <import-stmt> ] ...
+          [ <standalone-template-subprogram-declaration-construct> ] ...
 
-R2021 <standalone-template-subprogram-declaration-construct> <<is>>
-     <deferred-arg-decl-stmt>
-     <<or>> <format-stmt>
-     <<or>> <specification-construct>
+R2021 <standalone-template-subprogram-declaration-construct>
+          <<is>> <deferred-arg-decl-stmt>
+          <<or>> <format-stmt>
+          <<or>> <specification-construct>
 
 R2022 <standalone-template-function-stmt> <<is>>
-     [ <prefix> ] FUNCTION <template-name>
-         ( <deferred-arg-list> ) ([<dummy-arg-list>])
-	 [<suffix>]
+          [ <prefix> ] FUNCTION <template-name>
+          ( <deferred-arg-list> ) ([<dummy-arg-list>])
+          [<suffix>]
 
 R2023 <standalone-template-subroutine-stmt> <<is>>
-     [ <prefix> ] SUBROUTINE <template-name>
+         [ <prefix> ] SUBROUTINE <template-name>
          ( <deferred-arg-list> ) ([<dummy-arg-list>])
-	 [<proc-language-binding-spec>]
+         [<proc-language-binding-spec>]
 
 20.5 Restrictions on template definitions
 
 C2033. A variable or procedure pointer declared in either a
-	    <template-subprogram-part> or a
-	    <standalone-template-subprogram-declaration-construct> shall
-	    not have the SAVE attribute.
+       <template-subprogram-part> or a
+       <standalone-template-subprogram-declaration-construct> shall
+       not have the SAVE attribute.
 
 C2034. EQUIVALENCE and COMMON shall not appear in a
-            <template-subprogram-part> or a
-            <standalone-template-subprogram-declaration-construct>.
+       <template-subprogram-part> or a
+       <standalone-template-subprogram-declaration-construct>.
 
 
 C2035. <template>, <standalone-template-function-subprogram> and

--- a/J3-Papers/edits/24-164_instantiate.txt
+++ b/J3-Papers/edits/24-164_instantiate.txt
@@ -21,8 +21,8 @@ Straw vote: The INSTANTIATE and REQUIRE statements do not need "[::]"
             and REQUIRE statements?
 
             YES - omit the optional "[::]" in the BNF
-	    NO  - keep the optional "[::]" in the BNF
-	    ABSTAIN
+            NO  - keep the optional "[::]" in the BNF
+            ABSTAIN
 
 
 Section 1:
@@ -38,30 +38,30 @@ an instance of a template by specifying instantiation arguments that
 become associated with the deferred arguments of the named template.
 
 R2024 <template-instantiate-stmt>
-     <<is>> INSTANTIATE [::] <template-name> (
-            [ <instantiation-arg-spec-list> ] ) [, <rename-list> ]
-     <<or>> INSTANTIATE [::] <template-name> (
-            [ <instantiation-arg-spec-list> ] ), ONLY : [ <only-list> ]
+          <<is>> INSTANTIATE [::] <template-name> (
+                 [ <instantiation-arg-spec-list> ] ) [, <rename-list> ]
+          <<or>> INSTANTIATE [::] <template-name> (
+                 [ <instantiation-arg-spec-list> ] ), ONLY : [ <only-list> ]
 
 C2036 (R2024). <template-name> shall not be the name of a standalone
-            template procedure.
+               template procedure.
 
 R2025 <standalone-instantiate-stmt> <<is>>
-     INSTANTIATE [::] <template-name> (
-            [ <instantiation-arg-spec-list> ] ), [ONLY :] <local-name> => *
+          INSTANTIATE [::] <template-name> (
+          [ <instantiation-arg-spec-list> ] ), [ONLY :] <local-name> => *
 
 C2037 (R2025). <template-name> shall be the name of a standalone
-            template procedure.
+               template procedure.
 
 R2026 <instantiate-stmt> <<is>> <template-instantiate-stmt>
-                   <<or>> <standalone-instantiate-stmt>
+                         <<or>> <standalone-instantiate-stmt>
 
 C2038 (R2026). Within an <instantiate-stmt>, <instantiation-arg> shall
-            not depend on any entity defined within the referenced
-            template.
+               not depend on any entity defined within the referenced
+               template.
 
 C2039 (R2026). In <instantiate-stmt>, <template-name> shall not be the
-            name of any construct in which it appears.
+               name of any construct in which it appears.
 
 The INSTANTIATE statement without the ONLY option provides access to
 all public entities of the referenced template.  The INSTANTIATE
@@ -94,11 +94,11 @@ R2027 <inline-instantiate> <<is>>
     <template-name> ^ ( <instantiation-arg-spec-list> )
 
 C2040 (R2027). <template-name> shall be the name of a
-            <standalone-template-function-subprogram> or a
-            <standalone-template-subroutine-subprogram>
+               <standalone-template-function-subprogram> or a
+               <standalone-template-subroutine-subprogram>
 
 C2041 (R2027). In <inline-instantiate>, <template-name> shall not be the
-            name of any construct in which it appears.
+               name of any construct in which it appears.
 
 Note: Currently standalone template procedures cannot reference
       themselves.  Future work could relax this.
@@ -154,15 +154,15 @@ and only if both resolve to the same specific procedure.
 Note: Example showing how procedure instantiation arguments influence
       whether instantiations are the same.
 
-	INTERFACE
-	   SUBROUTINE F1(x)
-	      TYPE(MY_T) :: x
+        INTERFACE
+           SUBROUTINE F1(x)
+              TYPE(MY_T) :: x
            END SUBROUTINE
-	   SUBROUTINE F2(x)
-	      TYPE(MY_U) :: x
+           SUBROUTINE F2(x)
+              TYPE(MY_U) :: x
            END SUBROUTINE
-	   SUBROUTINE F3(x)
-	      TYPE(MY_U) :: x
+           SUBROUTINE F3(x)
+              TYPE(MY_U) :: x
            END SUBROUTINE
         END INTERFACE
 
@@ -193,10 +193,10 @@ Instantiation arguments are specified by an INSTANTIATE statement, a
 REQUIRE statement, or by inline instantiation.
 
 R2028 <instantiation-arg-spec> <<is>>
-        [ <keyword> = ] <instantiation-arg>
+          [ <keyword> = ] <instantiation-arg>
 
 C2042 (R2028). Each <keyword> shall be the name of a <deferred-arg> in
-            the referenced requirement or template.
+               the referenced requirement or template.
 
 In the absence of an argument keyword, an instantiation argument
 corresponds to the deferred argument occupying the corresponding
@@ -206,9 +206,9 @@ reduced list, the second instantiation argument corresponds to the
 second deferred argument in the reduced list, etc.
 
 R2029 <instantiation-arg> <<is>> <constant-expr>
-                    <<or>> <type-spec>
-                    <<or>> <generic-spec>
-                    <<or>> <procedure-name>
+                          <<or>> <type-spec>
+                          <<or>> <generic-spec>
+                          <<or>> <procedure-name>
 
 Note: <generic-spec> includes operators, defined assignment and
       defined I/O.  The last may be somewhat awkward to use within a
@@ -218,19 +218,19 @@ Note: <generic-spec> includes operators, defined assignment and
 20.6.4.2 Deferred type association
 
 C2043 (R2029). An <instantiation-arg> that is a <type-spec> shall
-            correspond to a <deferred-arg> that is a <deferred-type>
-            in the referenced template or requirement.
+               correspond to a <deferred-arg> that is a <deferred-type>
+               in the referenced template or requirement.
 
 C2044 (R2029). An <instantiation-arg> that is a <type-spec> shall have
-            constant type parameters.
+               constant type parameters.
 
 C2045 (R2029). An <instantiation-arg> that corresponds to a deferred type
-            that does not have the ABSTRACT attribute shall not be
-            abstract.
+               that does not have the ABSTRACT attribute shall not be
+               abstract.
 
 C2046 (R2029). An <instantiation-arg>, T, that corresponds to a deferred
-            type shall be a type for which a variable whose declared
-            type is T is permitted in a variable definition context.
+               type shall be a type for which a variable whose declared
+               type is T is permitted in a variable definition context.
 
 Note: This constraint ensures that intrinsic assignment of variables
       of deferred type is permitted within a template.  However, this
@@ -238,12 +238,12 @@ Note: This constraint ensures that intrinsic assignment of variables
       as an instantiation argument.
 
 C2047 (R2029). An <instantiation-arg> that corresponds to a deferred type
-            that has the EXTENSIBLE attribute shall be an extensible
-            derived type.
+               that has the EXTENSIBLE attribute shall be an extensible
+               derived type.
 
 C2048 (R2029). An <instantiation-arg> that corresponds to a deferred
-            type shall not have a coarray potential subobject
-            component.
+               type shall not have a coarray potential subobject
+               component.
 
 Note: The above constraint avoids the possibility of assignment
       being invalid where the variable and expr do not agree on
@@ -287,52 +287,52 @@ Note: Potentially allow INSTANTIATE statement for an standalone
 ##.6.4.3 Deferred constant association
 
 C2049 (R2029). <constant-expr> shall be type INTEGER, LOGICAL or
-            CHARACTER.
+               CHARACTER.
 
-C2050 (R2029).An <instantiation-arg> that is a <constant-expr> shall
-            correspond to a <deferred-arg> that is a <deferred-const>
-            in the referenced template or requirement.
+C2050 (R2029). An <instantiation-arg> that is a <constant-expr> shall
+               correspond to a <deferred-arg> that is a <deferred-const>
+               in the referenced template or requirement.
 
-C2051 (R2029).The type and kind of an <instantiation-arg> that is a
-            <constant-expr> shall have the same type and kind as the
-            corresponding <deferred-const> in the referenced template
-            or requirement.
+C2051 (R2029). The type and kind of an <instantiation-arg> that is a
+               <constant-expr> shall have the same type and kind as the
+               corresponding <deferred-const> in the referenced template
+               or requirement.
 
-C2052 (R2029).If the shape of the corresponding <deferred-const> in the
-            referenced template or requirement is not implied, then
-            <constant-expr> shall have the same shape.
+C2052 (R2029). If the shape of the corresponding <deferred-const> in the
+               referenced template or requirement is not implied, then
+               <constant-expr> shall have the same shape.
 
-C2053 (R2029).If the rank of the corresponding <deferred-const> in the
-            referenced template or requirement is not implied, then
-            <constant-expr> shall have the same rank.
+C2053 (R2029). If the rank of the corresponding <deferred-const> in the
+               referenced template or requirement is not implied, then
+               <constant-expr> shall have the same rank.
 
 
 ##.6.4.4 Deferred procedure association
 
-C2054 (R2029).An <instantiation-arg> that is a <generic-spec> or
-            <procedure-name> shall correspond to a <deferred-arg> that
-            is a deferred procedure in the referenced template or
-            requirement.
+C2054 (R2029). An <instantiation-arg> that is a <generic-spec> or
+               <procedure-name> shall correspond to a <deferred-arg> that
+               is a deferred procedure in the referenced template or
+               requirement.
 
-C2055 (R2029).An <instantiation-arg> that is a <procedure-name> shall
-            have the same characteristics as the corresponding
-            deferred procedure in the referenced template or requirement,
-            except that a pure instantiation argument may be
-            associated with a deferred argument that is not pure, a
-            simple instantiation argument may be associated with a
-            deferred argument that is not simple, and an elemental
-            instantiation argument may be associated with a deferred
-            procedure that is not elemental.
+C2055 (R2029). An <instantiation-arg> that is a <procedure-name> shall
+               have the same characteristics as the corresponding
+               deferred procedure in the referenced template or
+               requirement, except that a pure instantiation argument may
+               be associated with a deferred argument that is not pure, a
+               simple instantiation argument may be associated with a
+               deferred argument that is not simple, and an elemental
+               instantiation argument may be associated with a deferred
+               procedure that is not elemental.
 
 C2056. An <instantiation-arg> that is a <generic-spec> shall have
-            one specific procedure that has the same characteristics
-            as the corresponding deferred procedure the referenced
-            template or requirement, except that a pure instantiation
-            argument may be associated with a deferred argument that
-            is not pure, a simple instantiation argument may be
-            associated with a deferred argument that is not simple,
-            and an elemental instantiation argument may be associated
-            with a deferred procedure that is not elemental.
+       one specific procedure that has the same characteristics
+       as the corresponding deferred procedure the referenced
+       template or requirement, except that a pure instantiation
+       argument may be associated with a deferred argument that
+       is not pure, a simple instantiation argument may be
+       associated with a deferred argument that is not simple,
+       and an elemental instantiation argument may be associated
+       with a deferred procedure that is not elemental.
 
 The deferred procedure is associated with the specific procedure that is
 consistent with the characteristics.

--- a/J3-Papers/edits/24-165_requirement.txt
+++ b/J3-Papers/edits/24-165_requirement.txt
@@ -27,14 +27,14 @@ A REQUIREMENT is a named collection of deferred argument declarations
 intended to facilitate reuse of common patterns within templates and
 other requirements. A REQUIREMENT construct is a specification construct.
 
-R2041 <requirement>
-      <<is>> REQUIREMENT <requirement-name> ( [<deferred-arg-list>] )
-                [ <use-stmt> ] ...
-                <requirement-specification-construct> ...
-             END [REQUIREMENT [<requirement-name>]]
+R2041 <requirement> <<is>>
+          REQUIREMENT <requirement-name> ( [<deferred-arg-list>] )
+              [ <use-stmt> ] ...
+              <requirement-specification-construct> ...
+          END [REQUIREMENT [<requirement-name>]]
 
 C2057 (R2041). Each <deferred-arg> shall appear in a
-            <requirement-specification-construct>.
+               <requirement-specification-construct>.
 
 C2058 (R2041). If a <requirement-name> appears in the
                <end-requirement-stmt>, it shall be identical to the
@@ -46,8 +46,8 @@ Note: A <requirement> is a scoping unit that allows use, host, and
 Note: Each <deferred-arg> is local to the REQUIREMENT construct.
 
 R2042 <requirement-specification-construct>
-        <<is>> <deferred-arg-decl-stmt>
-        <<or>> <interface-block>
+          <<is>> <deferred-arg-decl-stmt>
+          <<or>> <interface-block>
 
 C2059 (R2042). <interface-stmt> shall include ABSTRACT or DEFERRED.
 
@@ -82,11 +82,11 @@ associating them with the deferred arguments of a REQUIREMENT. A
 REQUIRE statement is a specification statement.
 
 R2043 <require-stmt> <<is>>
-      REQUIRE [::] <requirement-name>
-            ( [<instantiation-arg-spec-list>] )
+          REQUIRE [::] <requirement-name>
+          ( [<instantiation-arg-spec-list>] )
 
 C2059 (R2043). <requirement-name> shall be the name of a previously
-            defined <requirement>.
+               defined <requirement>.
 
 Note: Instantiation arguments in a REQUIRE statement are not required
       to be deferred arguments.

--- a/J3-Papers/edits/24-166_misc.txt
+++ b/J3-Papers/edits/24-166_misc.txt
@@ -49,7 +49,7 @@ The contents of this paper are:
 * 7.3.2.1 Type specifier syntax
 
   Extend R702 <type-spec>:
-  " <<or>> <deferred-type>"
+    <<or>> <deferred-type>
 
   Extend C703 from:
     (R702) The <derived-type-spec> shall not specify an abstract
@@ -59,8 +59,8 @@ The contents of this paper are:
     an abstract type (7.5.7) except when used as an <instantiation-arg>.
 
   Extend R703 <declaration-type-spec> to include:
-      <<or>> TYPE(<deferred-type>)
-      <<or>> CLASS(<deferred-type>)
+    <<or>> TYPE(<deferred-type>)
+    <<or>> CLASS(<deferred-type>)
 
   Change C706 from:
     (R703) TYPE(<derived-type-spec>) shall not specify an abstract
@@ -80,69 +80,60 @@ The contents of this paper are:
 
 * 7.5.2.1 Syntax of a derived-type definition
 
-  New constraint on R728:
-
-  C737b (R728)  "<parent-type-name> shall not be a <deferred-type>.
+  Insert new constraint on R728:
+    C737b (R728) <parent-type-name> shall not be a <deferred-type>.
 
 * 8.5.2 Accessibility attribute
 
 [106:6] In C817, insert "or template" after "module", so that it now reads:
 
   C817 An access-spec shall appear only in the specification-part of a
-  module or template construct.
+       module or template construct.
 
 * 8.6.1 Accessibility Statement
 
-[120:28] Change C873 to read:
+  [120:28] Change C873 to read:
+    C873 (R831) An <access-stmt> shall appear only in the
+                <specification-part> of a module or template. Only one
+                accessibility statement with an omitted <access-id-list>
+                is permitted in the <specification-part> of a module or
+                template.
 
-C873 (R831) An <access-stmt> shall appear only in the
-            <specification-part> of a module or template. Only one
-            accessibility statement with an omitted <access-id-list>
-            is permitted in the <specification-part> of a module or
-            template.
+  [120:30] Change C874 to read:
+    C874 (R831) Each <access-name> shall be the name of a module,
+                variable, procedure, nonintrinsic type, named constant
+                other than a deferred constant, namelist group,
+                requirement, or template.
 
-[120:30] Change C874 to read:
+  [120:37+] In 2nd sentence of paragraph 1, insert "or template" after
+            "in the module" in both locations such that the sentence now
+            reads:
+    An access-stmt without an access-id list specifies the default
+    accessibility of the identifiers of entities declared in the
+    module or template, and of entities accessed from a module
+    whose name does not appear in any access-stmt in the module or
+    template.
 
-C874 (R831) Each <access-name> shall be the name of a module,
-            variable, procedure, nonintrinsic type, named constant
-            other than a deferred constant, namelist group,
-            requirement, or template.
+  [120:43] In last sentence of paragraph 1, insert "or template" after
+           "in a module" such that the sentence now reads:
+    If no such statement appears in a module or template, the
+    default is public accessibility.
 
-[120:37+] In 2nd sentence of paragraph 1, insert "or template" after
-          "in the module" in both locations such that the sentence now
-          reads:
-
-      "An access-stmt without an access-id list specifies the default
-       accessibility of the identifiers of entities declared in the
-       module or template, and of entities accessed from a module
-       whose name does not appear in any access-stmt in the module or
-       template."
-
-[120:43] In last sentence of paragraph 1, insert "or template" after
-          "in a module" such that the sentence now reads:
-
-      "If no such statement appears in a module or template, the
-       default is public accessibility."
-
-[121:1] In 1st sentence of paragraph 2, insert "or template" after "in
-        the module" such that the sentence now reads:
-
-     "If an identifier is accessed by use association and not declared
-     in the module or template, and the name of every module from
-     which it is accessed appears in an access-stmt in the scoping
-     unit, its default accessibility is PRIVATE if the access-spec in
-     every such access-stmt is PRIVATE, or PUBLIC if the access-spec
-     in any such access-stmt is PUBLIC."
+  [121:1] In 1st sentence of paragraph 2, insert "or template" after "in
+          the module" such that the sentence now reads:
+    If an identifier is accessed by use association and not declared
+    in the module or template, and the name of every module from
+    which it is accessed appears in an access-stmt in the scoping
+    unit, its default accessibility is PRIVATE if the access-spec in
+    every such access-stmt is PRIVATE, or PUBLIC if the access-spec
+    in any such access-stmt is PUBLIC.
 
 * 8.5.8.1 General
 
-  Change last entry for <array-spec>
-
-  From:
-      <<or>>   <assumed-rank-spec>
-
+  Change last entry for <array-spec> from:
+    <<or>>   <assumed-rank-spec>
   To:
-      <<or>>   <assumed-or-implied-rank-spec>
+    <<or>>   <assumed-or-implied-rank-spec>
 
 * 8.5.8.2 Explicit-shape array
 
@@ -155,12 +146,9 @@ would make constraint for deferred constants clearer.
 * 8.5.8.6 Implied-shape array
 
   Modify the first sentence from:
-
     An implied-shape array is a named constant that takes its shape
     from the constant-expr in its declaration.
-
   To:
-
     An implied-shape array is a named constant that takes its shape
     from a constant expression. If it is a deferred constant, it takes
     its shape from the associated instantiation argument, otherwise it
@@ -171,49 +159,43 @@ would make constraint for deferred constants clearer.
     The extent of each dimension of an implied-shape array is the same
     as the extent of the corresponding dimension of the constant-expr.
 
-Add new section after 8.5.8.7
+  Insert new section after 8.5.8.7
 
-  8.5.8.7b Implied-rank entity
+    8.5.8.7b Implied-rank entity
 
-  An implied-rank entity is an entity whose rank becomes defined only
-  when the template in which it appears is instantiated.
+    An implied-rank entity is an entity whose rank becomes defined only
+    when the template in which it appears is instantiated.
 
-  Note: Also make sure it works with SELECT GENERIC RANK and spell out
-      what can be done with implied-rank entities.
+    Note: Also make sure it works with SELECT GENERIC RANK and spell out
+          what can be done with implied-rank entities.
 
-  R287b <implied-rank-spec> <<is>> ..
+    R287b <implied-rank-spec> <<is>> ..
 
-  C841b (R287b).  An implied-rank entity shall be a <deferred-const>.
+    C841b (R287b).  An implied-rank entity shall be a <deferred-const>.
 
-   Note: Examples of implied-rank entities
+    Note: Examples of implied-rank entities
 
-   TEMPLATE EXAMPLE(C, S, N)
-      INTEGER, DEFERRED, PARAMETER :: C(..) ! implied-shape & implied-rank
-      INTEGER, DEFERRED, PARAMETER :: S(*), N
-      INTEGER, PARAMETER :: B(S) = 1 ! explicit-shape & implied-rank
-   END TEMPLATE
+    TEMPLATE EXAMPLE(C, S, N)
+       INTEGER, DEFERRED, PARAMETER :: C(..) ! implied-shape & implied-rank
+       INTEGER, DEFERRED, PARAMETER :: S(*), N
+       INTEGER, PARAMETER :: B(S) = 1 ! explicit-shape & implied-rank
+    END TEMPLATE
 
 * 8.5.17  RANK clause
 
   Replace constraint C864 which states:
-
-  C864  An entity declared with a rank-clause shall be a dummy data
-     object or have the ALLOCATABLE or POINTER attribute.
-
+    C864  An entity declared with a rank-clause shall be a dummy data
+          object or have the ALLOCATABLE or POINTER attribute.
   With:
-
-  C864   An entity declared with a rank-clause shall be a named constant,
-     dummy data object or have the ALLOCATABLE or POINTER attribute.
+    C864  An entity declared with a rank-clause shall be a named constant,
+          dummy data object or have the ALLOCATABLE or POINTER attribute.
 
   Replace the last paragraph:
-
     If the rank is zero the entity is scalar; otherwise, if it has
     the ALLOCATABLE or POINTER attribute, it specifies that it is a
     deferred-shape array; otherwise, it specifies that it is an
     assumed-shape array with all the lower bounds equal to one.
-
   With:
-
     If the rank is zero the entity is scalar; otherwise, if it has
     the ALLOCATABLE or POINTER attribute, it specifies that it is a
     deferred-shape array; otherwise, if it is a named constant, it
@@ -263,12 +245,12 @@ Modify C873 to read as
 
 UTI: spelling of <inline-instantiate> vs <inline-instantiation>
 
-  Extend R1522 <procedure-designator>:
-  " <<or>> <deferred-proc>"
-  " <<or>> <inline-instantiate>"
+  Extend R1522 <procedure-designator> with:
+    <<or>> <deferred-proc>
+    <<or>> <inline-instantiate>
 
   Extend R1524 <actual-arg> with:
-  " <<or>> <deferred-proc> "
+    <<or>> <deferred-proc>
     <<or>> <inline-instantiate>
 
 3. Edits required for templates and instantiation
@@ -277,15 +259,15 @@ UTI: spelling of <inline-instantiate> vs <inline-instantiation>
 * 5.1 High level syntax
 
   Extend R508 <specification-construct> to include:
-        <<or>> <template>
-        <<or>> <requirement>
-        <<or>> <instantiate-stmt>
+    <<or>> <template>
+    <<or>> <requirement>
+    <<or>> <instantiate-stmt>
 
   C501 (R508). <template> or <requirement> shall only appear in a
-                    <program> or a <module>.
+               <program> or a <module>.
 
   Extend R512 to be:
-     R512 <internal-subprogram>
+    R512 <internal-subprogram>
          <<is>> <function-subprogram>
          <<or>> <subroutine-subprogram>
          <<or>> <standalone-template-subroutine-subprogram>
@@ -294,87 +276,72 @@ UTI: spelling of <inline-instantiate> vs <inline-instantiation>
 
 * 8.7 IMPLICIT Statement
 
-Modify last sentence in para 3 on page 127 from:
-
-If a mapping is not specified for a letter, the default
-for a program unit or an interface body is default integer if the
-letter is I, J, ..., or N and default real otherwise, and the default
-for a BLOCK construct, internal subprogram, or module subprogram is
-the mapping in the host scoping unit.
-
-To:
-
-If a mapping is not specified for a letter, the default for a program
-unit or an interface body that does not appear in a deferred interface
-block is default integer if the letter is I, J, ..., or N and default
-real otherwise.  The default for a BLOCK construct, internal
-subprogram, or module subprogram is the mapping in the host scoping
-unit.  The default for an interface body inside of a deferred
-interface block is as if IMPLICIT NONE(TYPE, EXTERNAL) appeared.
+  Modify last sentence in para 3 on page 127 from:
+    If a mapping is not specified for a letter, the default
+    for a program unit or an interface body is default integer if the
+    letter is I, J, ..., or N and default real otherwise, and the default
+    for a BLOCK construct, internal subprogram, or module subprogram is
+    the mapping in the host scoping unit.
+  To:
+    If a mapping is not specified for a letter, the default for a program
+    unit or an interface body that does not appear in a deferred interface
+    block is default integer if the letter is I, J, ..., or N and default
+    real otherwise.  The default for a BLOCK construct, internal
+    subprogram, or module subprogram is the mapping in the host scoping
+    unit.  The default for an interface body inside of a deferred
+    interface block is as if IMPLICIT NONE(TYPE, EXTERNAL) appeared.
 
 
 * 8.8p2 IMPORT Statement
 
   Modify sentence 2 in p2 from:
-
-     This is the default for an interface body that is not a module
-     procedure interface body.
-
-     To:
-
-     This is the default for an interface body that is not a module
-     procedure interface body or an interface body that appears in a
-     deferred interface block.
+    This is the default for an interface body that is not a module
+    procedure interface body.
+  To:
+    This is the default for an interface body that is not a module
+    procedure interface body or an interface body that appears in a
+    deferred interface block.
 
   Modify sentence 2 in p4 from:
-
-     This is the default for a derived-type definition, internal
-     subprogram, module procedure interface body, module subprogram,
-     or submodule.
-
+    This is the default for a derived-type definition, internal
+    subprogram, module procedure interface body, module subprogram,
+    or submodule.
   To:
-
-     This is the default for a derived-type definition, internal
-     subprogram, module procedure interface body, module subprogram,
-     submodule, or an interface body that appears in a deferred
-     interface block.
+    This is the default for a derived-type definition, internal
+    subprogram, module procedure interface body, module subprogram,
+    submodule, or an interface body that appears in a deferred
+    interface block.
 
 
 * 14.2.1 Module syntax and semantics
 
-Rule 1408 becomes
-
-R1408 <module-subprogram>
-    <<is>> <function-subprogram>
-    <<or>> <subroutine-subprogram>
-    <<or>> <separate-module-subprogram>
-    <<or>> <standalone-template-function-subprogram>
-    <<or>> <standalone-template-subroutine-subprogram>
+  Modify R1408 to become:
+    R1408 <module-subprogram>
+              <<is>> <function-subprogram>
+              <<or>> <subroutine-subprogram>
+              <<or>> <separate-module-subprogram>
+              <<or>> <standalone-template-function-subprogram>
+              <<or>> <standalone-template-subroutine-subprogram>
 
 * 15.4.3.2 Interface block
 
-Change:
+  Change R1503 from:
+    R1503 <interface-stmt> <<is>> INTERFACE [ <generic-spec> ]
+                           <<or>> ABSTRACT INTERFACE
+  To:
+    R1503 <interface-stmt> <<is>> INTERFACE [ <generic-spec> ]
+                           <<or>> ABSTRACT INTERFACE
+                           <<or>> DEFERRED INTERFACE
 
-R1503 <interface-stmt> <<is>> INTERFACE [ <generic-spec> ]
-                       <<or>> ABSTRACT INTERFACE
-
-To read:
-
-R1503 <interface-stmt> <<is>> INTERFACE [ <generic-spec> ]
-                       <<or>> ABSTRACT INTERFACE
-                       <<or>> DEFERRED INTERFACE
-
-Change final sentence in para 2 such that the sentence reads:
-
-  An interface block without ABSTRACT, DEFERRED, or a generic
-  specification is a specific interface block.
+  Change final sentence in para 2 such that the sentence reads:
+    An interface block without ABSTRACT, DEFERRED, or a generic
+    specification is a specific interface block.
 
 
-Add after para 2:
-
-  An interface block introduced by DEFERRED INTERFACE is a deferred
-  interface block. An interface body in a deferred interface block
-  specifies a deferred procedure.
+  Add after para 2:
+    An interface block introduced by DEFERRED INTERFACE is a deferred
+    interface block. An interface body in a deferred interface block
+    specifies a deferred procedure.
 
 * 15.6.2.2 Function subprogram
 
@@ -382,7 +349,7 @@ Add after para 2:
 
   Note: <end-function-stmt> is reused for standalone template
         procedures.  Therefore the constraint must be attached to a
-        different rule to be applicable in both situation.
+        different rule to be applicable in both situations.
 
 * 15.6.2.3 Subroutine subprogram
 
@@ -390,66 +357,65 @@ Add after para 2:
 
   Note: <end-subroutine-stmt> is reused for standalone template
         procedures.  Therefore the constraint must be attached to a
-        different rule to be applicable in both situation.
+        different rule to be applicable in both situations.
 
 4. Edits to TKR compatibility
 =============================
 
-An entity whose rank is, or depends on, a deferred argument does not
-have the same rank as any other entity, unless that entity has its
-rank defined with a syntactically equivalent expression. If the rank of an
-implied-rank entity is not declared with a rank clause, it is considered
-to have no expression for its rank, and therefore does not have the same
-rank as any other entity.
+  An entity whose rank is, or depends on, a deferred argument does not
+  have the same rank as any other entity, unless that entity has its
+  rank defined with a syntactically equivalent expression. If the rank
+  of an implied-rank entity is not declared with a rank clause, it is
+  considered to have no expression for its rank, and therefore does not
+  have the same rank as any other entity.
 
-An entity whose kind is, or depends on, a deferred argument does not
-have the same kind as any other entity, unless that entity has its
-kind defined with a syntactically equivalent expression.
+  An entity whose kind is, or depends on, a deferred argument does not
+  have the same kind as any other entity, unless that entity has its
+  kind defined with a syntactically equivalent expression.
 
-Note: Some examples of implied-rank entities are shown
-      in the following example template. C is explicitly declared
-      as implied-rank. B is implied-rank because its rank depends on
-      the size of the deferred argument S. X, Y and Z are implied-rank
-      because their ranks depend on the value of the deferred argument N.
+  Note: Some examples of implied-rank entities are shown
+        in the following example template. C is explicitly declared
+        as implied-rank. B is implied-rank because its rank depends on
+        the size of the deferred argument S. X, Y and Z are implied-rank
+        because their ranks depend on the value of the deferred argument N.
 
-  TEMPLATE EXAMPLE(C, S, N)
-    INTEGER, DEFERRED, PARAMETER :: C(..) ! implied-shape & implied-rank
-    INTEGER, DEFERRED, PARAMETER :: S(*), N
-    INTEGER, PARAMETER :: B(S) = 1 ! explicit-shape & implied-rank
-  CONTAINS
-    SUBROUTINE SUB(X)
-      INTEGER, RANK(N) :: X ! assumed-shape & implied-rank
-      INTEGER :: Y([(i, i = 1, N)]) ! explicit-shape & implied-rank
-      INTEGER, RANK(N), ALLOCATABLE :: Z ! deferred-shape & implied-rank
-      call sub_explicit(C) ! valid, element order association
-      ! call sub_assumed(C) ! invalid, rank expressions don't match
-      ! call sub_same_rank(C) ! invalid, rank expressions don't match
+    TEMPLATE EXAMPLE(C, S, N)
+      INTEGER, DEFERRED, PARAMETER :: C(..) ! implied-shape & implied-rank
+      INTEGER, DEFERRED, PARAMETER :: S(*), N
+      INTEGER, PARAMETER :: B(S) = 1 ! explicit-shape & implied-rank
+    CONTAINS
+      SUBROUTINE SUB(X)
+        INTEGER, RANK(N) :: X ! assumed-shape & implied-rank
+        INTEGER :: Y([(i, i = 1, N)]) ! explicit-shape & implied-rank
+        INTEGER, RANK(N), ALLOCATABLE :: Z ! deferred-shape & implied-rank
+        call sub_explicit(C) ! valid, element order association
+        ! call sub_assumed(C) ! invalid, rank expressions don't match
+        ! call sub_same_rank(C) ! invalid, rank expressions don't match
 
-      call sub_explicit(X) ! valid, element order association
-      ! call sub_assumed(X) ! invalid, rank expressions don't match
-      call sub_same_rank(X) ! valid, rank expressions match
+        call sub_explicit(X) ! valid, element order association
+        ! call sub_assumed(X) ! invalid, rank expressions don't match
+        call sub_same_rank(X) ! valid, rank expressions match
 
-      call sub_explicit(Y) ! valid, element order association
-      ! call sub_assumed(Y) ! invalid, rank expressions don't match
-      ! call sub_same_rank(Y) ! invalid, rank expressions don't match
-    END SUBROUTINE
-    SUBROUTINE SUB_EXPLICIT(X)
-      INTEGER :: X(10)
-    END SUBROUTINE
-    SUBROUTINE SUB_ASSUMED(X)
-      INTEGER :: X(:)
-    END SUBROUTINE
-    SUBROUTINE SUB_SAME_RANK(X)
-      INTEGER, RANK(N) :: X
-    END SUBROUTINE
-  END TEMPLATE
+        call sub_explicit(Y) ! valid, element order association
+        ! call sub_assumed(Y) ! invalid, rank expressions don't match
+        ! call sub_same_rank(Y) ! invalid, rank expressions don't match
+      END SUBROUTINE
+      SUBROUTINE SUB_EXPLICIT(X)
+        INTEGER :: X(10)
+      END SUBROUTINE
+      SUBROUTINE SUB_ASSUMED(X)
+        INTEGER :: X(:)
+      END SUBROUTINE
+      SUBROUTINE SUB_SAME_RANK(X)
+        INTEGER, RANK(N) :: X
+      END SUBROUTINE
+    END TEMPLATE
 
 5. Edits for A.2 Processor Dependencies
 =======================================
 
-[555:15+] Insert new bullet:
-
-   * the names of the dummy arguments of a deferred procedure without
-     an explicit specification (20.2.2.4);
+  [555:15+] Insert new bullet:
+    * the names of the dummy arguments of a deferred procedure without
+      an explicit specification (20.2.2.4);
 
 ===END===


### PR DESCRIPTION
Well 161 and 162 are already up for vote, so maybe we shouldn't change those yet. If/when they need a revision, we can possibly apply these formatting changes to them too. But for the others, we can apply them now, if you all agree.

This fixes some tabs and alignment of constraint text. The bulk of the formatting is in the misc edits paper, where I try to make the wording and formatting more consistent across all the many small edits in that paper.