### PR TITLE
Replace proposed C501 with constraints on <template> and <requirement>

### DIFF
--- a/J3-Papers/edits/24-163_templates.txt
+++ b/J3-Papers/edits/24-163_templates.txt
@@ -26,14 +26,17 @@ R2010 <template> <<is>> <template-stmt>
                       [ <template-subprogram-part> ]
                       <end-template-stmt>
 
+C2027a (R2010). A <template> shall only appear in the <specification-part>
+                of a main program or module.
+
 R2011 <template-stmt> <<is>>
           TEMPLATE <template-name> ([<deferred-arg-list>])
 
 R2012 <end-template-stmt> <<is>>  END [TEMPLATE [<template-name>]]
 
-C2027 (R2012). If a <template-name> appears in the <end-template-stmt>,
-            it shall be identical to the <template-name>
-            specified in the <template-stmt>.
+C2027b (R2012). If a <template-name> appears in the <end-template-stmt>,
+                it shall be identical to the <template-name>
+                specified in the <template-stmt>.
 
 20.3.2 Template specification part
 

--- a/J3-Papers/edits/24-165_requirement.txt
+++ b/J3-Papers/edits/24-165_requirement.txt
@@ -33,8 +33,11 @@ R2041 <requirement>
                 <requirement-specification-construct> ...
              END [REQUIREMENT [<requirement-name>]]
 
-C2057 (R2041). Each <deferred-arg> shall appear in a
-            <requirement-specification-construct>.
+C2057a (R2041). A <requirement> shall only appear in the <specification-part>
+                of a main program or module.
+
+C2057b (R2041). Each <deferred-arg> shall appear as the name of an entity
+                declared by a <requirement-specification-construct>.
 
 C2058 (R2041). If a <requirement-name> appears in the
                <end-requirement-stmt>, it shall be identical to the

--- a/J3-Papers/edits/24-166_misc.txt
+++ b/J3-Papers/edits/24-166_misc.txt
@@ -5,9 +5,6 @@ Date: 2024-October-07
 References: 24-161, 24-162, 24-163, 24-164, 24-165,
             24-125r5, 24-126r4, 24-127r4, 24-007
 
-UTI: Constraint on R508 is unprecedented.  No other constraints in all
-     of clause 5.
-
 UTI: Section 4 does not seem to state where it goes in the standard
 
 1. Introduction
@@ -280,9 +277,6 @@ UTI: spelling of <inline-instantiate> vs <inline-instantiation>
         <<or>> <template>
         <<or>> <requirement>
         <<or>> <instantiate-stmt>
-
-  C501 (R508). <template> or <requirement> shall only appear in a
-                    <program> or a <module>.
 
   Extend R512 to be:
      R512 <internal-subprogram>


### PR DESCRIPTION
I based the new constraints off of C873, which limits the accessibility statement to only modules.

Also, I noticed C2057 (now C2057b to make room for the new constraint) was a bit vague, so I updated it to be more explicit about _how_ the \<deferred-arg\> needs to appear.

@tclune @everythingfunctional 